### PR TITLE
Provide a way to use a primary private key that isn't stored in blocktrail servers

### DIFF
--- a/examples/not_so_simple_payment_api_example.php
+++ b/examples/not_so_simple_payment_api_example.php
@@ -1,0 +1,50 @@
+<?php
+
+use Blocktrail\SDK\BlocktrailSDK;
+use Blocktrail\SDK\Connection\Exceptions\ObjectNotFound;
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
+$client = new BlocktrailSDK("MY_APIKEY", "MY_APISECRET", "BTC", true /* testnet */, 'v1');
+// $client->setVerboseErrors();
+// $client->setCurlDebugging();
+
+$primaryPrivateKey = ["tprv8ZgxMBicQKsPdMD2AYgpezVQZNi5kxsRJDpQWc5E9mxp747KgzekJbCkvhqv6sBTDErTjkWqZdY14rLP1YL3cJawEtEp2dufHxPhr1YUoeS", "m"];
+$backupPublicKey = ["tpubD6NzVbkrYhZ4Y6Ny2VF2o5wkBGuZLQAsGPn88Y4JzKZH9siB85txQyYq3sDjRBFwnE1YhdthmHWWAurJu7EetmdeJH9M5jz3Chk7Ymw2oyf", "M"];
+
+/**
+ * @var $wallet             \Blocktrail\SDK\WalletInterface
+ * @var $backupMnemonic     string
+ */
+try {
+    $wallet = $client->initWallet([
+        "identifier" => "example-wallet",
+        "primary_private_key" => $primaryPrivateKey,
+        "primary_mnemonic" => false
+    ]);
+} catch (ObjectNotFound $e) {
+    list($wallet, $primaryMnemonic, $backupMnemonic, $blocktrailPublicKeys) = $client->createNewWallet([
+        "identifier" => "example-wallet",
+        "primary_private_key" => $primaryPrivateKey,
+        "backup_public_key" => $backupPublicKey,
+        "key_index" => 9999
+    ]);
+    $wallet->doDiscovery();
+}
+
+// var_dump($wallet->deleteWebhook());
+// var_dump($wallet->setupWebhook("http://www.example.com/wallet/webhook/example-wallet"));
+
+// print some new addresses
+var_dump($wallet->getAddressByPath("M/9999'/0/0"), $wallet->getAddressByPath("M/9999'/0/1"));
+
+// print the balance
+list($confirmed, $unconfirmed) = $wallet->getBalance();
+var_dump($confirmed, BlocktrailSDK::toBTC($confirmed));
+var_dump($unconfirmed, BlocktrailSDK::toBTC($unconfirmed));
+
+// send a payment (will fail unless you've send some BTC to an address part of this wallet)
+$addr = $wallet->getNewAddress();
+var_dump($wallet->pay([
+    $addr => BlocktrailSDK::toSatoshi(0.001),
+]));

--- a/examples/simple_payment_api_example.php
+++ b/examples/simple_payment_api_example.php
@@ -14,9 +14,16 @@ $client = new BlocktrailSDK("MY_APIKEY", "MY_APISECRET", "BTC", true /* testnet 
  * @var $backupMnemonic     string
  */
 try {
-    $wallet = $client->initWallet("example-wallet", "example-strong-password");
+    $wallet = $client->initWallet([
+        "identifier" => "example-wallet",
+        "passphrase" => "example-strong-password"
+    ]);
 } catch (ObjectNotFound $e) {
-    list($wallet, $primaryMnemonic, $backupMnemonic, $blocktrailPublicKeys) = $client->createNewWallet("example-wallet", "example-strong-password", $_account=9999);
+    list($wallet, $primaryMnemonic, $backupMnemonic, $blocktrailPublicKeys) = $client->createNewWallet([
+        "identifier" => "example-wallet",
+        "passphrase" => "example-strong-password",
+        "key_index" => 9999
+    ]);
     $wallet->doDiscovery();
 }
 

--- a/src/BlocktrailSDK.php
+++ b/src/BlocktrailSDK.php
@@ -494,15 +494,70 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
 
         $walletPath = WalletPath::create($keyIndex);
 
-        // create new primary seed
-        list($primaryMnemonic, $primarySeed, $primaryPrivateKey) = $this->newPrimarySeed($password);
+        $storePrimaryMnemonic = isset($options['store_primary_mnemonic']) ? $options['store_primary_mnemonic'] : null;
+
+        if (isset($options['primary_mnemonic']) && $options['primary_private_key']) {
+            throw new \InvalidArgumentException("Can't specify Primary Mnemonic and Primary PrivateKey");
+        }
+
+        $primaryMnemonic = null;
+        $primaryPrivateKey = null;
+        if (!isset($options['primary_mnemonic']) && !isset($options['primary_private_key'])) {
+            if (!$password) {
+                throw new \InvalidArgumentException("Can't generate Primary Mnemonic without a passphrase");
+            } else {
+                // create new primary seed
+                list($primaryMnemonic, $primarySeed, $primaryPrivateKey) = $this->newPrimarySeed($password);
+                if ($storePrimaryMnemonic !== false) {
+                    $storePrimaryMnemonic = true;
+                }
+            }
+        } else if (isset($options['primary_mnemonic'])) {
+            $primaryMnemonic = $options['primary_mnemonic'];
+        } else if (isset($options['primary_private_key'])) {
+            $primaryPrivateKey = $options['primary_private_key'];
+        }
+
+        if ($storePrimaryMnemonic && $primaryMnemonic && !$password) {
+            throw new \InvalidArgumentException("Can't store Primary Mnemonic on server without a passphrase");
+        }
+
+        if ($primaryPrivateKey) {
+            if (is_string($primaryPrivateKey)) {
+                $primaryPrivateKey = [$primaryPrivateKey, "m"];
+            }
+        } else {
+            $primaryPrivateKey = BIP32::master_key(BIP39::mnemonicToSeedHex($primaryMnemonic, $password), 'bitcoin', $this->testnet);
+        }
+
+        if (!$storePrimaryMnemonic) {
+            $primaryMnemonic = false;
+        }
+
         // create primary public key from the created private key
         $primaryPublicKey = BIP32::build_key($primaryPrivateKey, (string)$walletPath->keyIndexPath()->publicPath());
 
-        // create new backup seed
-        list($backupMnemonic, $backupSeed, $backupPrivateKey) = $this->newBackupSeed();
-        // create backup public key from the created private key
-        $backupPublicKey = BIP32::build_key($backupPrivateKey, "M");
+        if (isset($options['backup_mnemonic']) && $options['backup_public_key']) {
+            throw new \InvalidArgumentException("Can't specify Backup Mnemonic and Backup PublicKey");
+        }
+
+        $backupMnemonic = null;
+        $backupPublicKey = null;
+        if (!isset($options['backup_mnemonic']) && !isset($options['backup_public_key'])) {
+            list($backupMnemonic, $backupSeed, $backupPrivateKey) = $this->newBackupSeed();
+        } else if (isset($options['backup_mnemonic'])) {
+            $backupMnemonic = $options['backup_mnemonic'];
+        } else if (isset($options['backup_public_key'])) {
+            $backupPublicKey = $options['backup_public_key'];
+        }
+
+        if ($backupPublicKey) {
+            if (is_string($backupPublicKey)) {
+                $backupPublicKey = [$backupPublicKey, "m"];
+            }
+        } else {
+            $backupPublicKey = BIP32::extended_private_to_public(BIP32::master_key(BIP39::mnemonicToSeedHex($backupMnemonic, ""), 'bitcoin', $this->testnet));
+        }
 
         // create a checksum of our private key which we'll later use to verify we used the right password
         $checksum = BlocktrailSDK::createChecksum($primaryPrivateKey);
@@ -606,16 +661,35 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
         }
 
         // explode the wallet data
-        $primaryMnemonic = $data['primary_mnemonic'];
+        $primaryMnemonic = isset($options['primary_mnemonic']) ? $options['primary_mnemonic'] : $data['primary_mnemonic'];
+        $primaryPrivateKey = isset($options['primary_private_key']) ? $options['primary_private_key'] : null;
         $checksum = $data['checksum'];
         $backupPublicKey = $data['backup_public_key'];
         $blocktrailPublicKeys = $data['blocktrail_public_keys'];
-        $keyIndex = $data['key_index'];
+        $keyIndex = isset($options['key_index']) ? $options['key_index'] : $data['key_index'];
 
-        // convert the mnemonic to a seed using BIP39 standard
-        $primarySeed = BIP39::mnemonicToSeedHex($primaryMnemonic, $password);
-        // create BIP32 private key from the seed
-        $primaryPrivateKey = BIP32::master_key($primarySeed, $this->network, $this->testnet);
+        if ($primaryMnemonic && $primaryPrivateKey) {
+            throw new \InvalidArgumentException("Can't specify Primary Mnemonic and Primary PrivateKey");
+        }
+
+        if (!$primaryMnemonic && !$primaryPrivateKey) {
+            throw new \InvalidArgumentException("Can't init wallet with Primary Mnemonic or Primary PrivateKey");
+        }
+
+        if ($primaryMnemonic && !$password) {
+            throw new \InvalidArgumentException("Can't init wallet with Primary Mnemonic without a passphrase");
+        }
+
+        if ($primaryPrivateKey) {
+            if (is_string($primaryPrivateKey)) {
+                $primaryPrivateKey = [$primaryPrivateKey, "m"];
+            }
+        } else {
+            // convert the mnemonic to a seed using BIP39 standard
+            $primarySeed = BIP39::mnemonicToSeedHex($primaryMnemonic, $password);
+            // create BIP32 private key from the seed
+            $primaryPrivateKey = BIP32::master_key($primarySeed, $this->network, $this->testnet);
+        }
 
         // create checksum (address) of the primary privatekey to compare to the stored checksum
         $checksum2 = $this->createChecksum($primaryPrivateKey);

--- a/src/BlocktrailSDK.php
+++ b/src/BlocktrailSDK.php
@@ -467,13 +467,31 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
      *   - send the primary seed (BIP39 'encrypted') and backup public key to the server
      *   - receive the blocktrail co-signing public key from the server
      *
-     * @param      $identifier
-     * @param      $password
-     * @param int  $keyIndex         override for the blocktrail cosigning key to use
+     * Either takes one argument:
+     * @param array $options
+     *
+     * Or takes three arguments (old, deprecated syntax):
+     * (@nonPHP-doc) @param      $identifier
+     * (@nonPHP-doc) @param      $password
+     * (@nonPHP-doc) @param int  $keyIndex         override for the blocktrail cosigning key to use
+     *
      * @return array[WalletInterface, (string)primaryMnemonic, (string)backupMnemonic]
      * @throws \Exception
      */
-    public function createNewWallet($identifier, $password, $keyIndex = 0) {
+    public function createNewWallet($options) {
+        if (!is_array($options)) {
+            $args = func_get_args();
+            $options = [
+                "identifier" => $args[0],
+                "password" => $args[1],
+                "key_index" => isset($args[2]) ? $args[2] : null,
+            ];
+        }
+
+        $identifier = $options['identifier'];
+        $password = isset($options['passphrase']) ? $options['passphrase'] : (isset($options['password']) ? $options['password'] : null);
+        $keyIndex = isset($options['key_index']) ? $options['key_index'] : 0;
+
         $walletPath = WalletPath::create($keyIndex);
 
         // create new primary seed
@@ -558,12 +576,28 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
     /**
      * initialize a previously created wallet
      *
-     * @param string    $identifier             the wallet identifier to be initialized
-     * @param string    $password               the password to decrypt the mnemonic with
+     * Either takes one argument:
+     * @param array $options
+     *
+     * Or takes two arguments (old, deprecated syntax):
+     * (@nonPHP-doc) @param string    $identifier             the wallet identifier to be initialized
+     * (@nonPHP-doc) @param string    $password               the password to decrypt the mnemonic with
+     *
      * @return WalletInterface
      * @throws \Exception
      */
-    public function initWallet($identifier, $password) {
+    public function initWallet($options) {
+        if (!is_array($options)) {
+            $args = func_get_args();
+            $options = [
+                "identifier" => $args[0],
+                "password" => $args[1],
+            ];
+        }
+
+        $identifier = $options['identifier'];
+        $password = isset($options['passphrase']) ? $options['passphrase'] : (isset($options['password']) ? $options['password'] : null);
+
         // get the wallet data from the server
         $data = $this->getWallet($identifier);
 

--- a/src/BlocktrailSDKInterface.php
+++ b/src/BlocktrailSDKInterface.php
@@ -232,13 +232,18 @@ interface BlocktrailSDKInterface {
      *   - send the primary seed (BIP39 'encrypted') and backup public key to the server
      *   - receive the blocktrail co-signing public key from the server
      *
-     * @param      $identifier
-     * @param      $password
-     * @param int  $keyIndex         override for the blocktrail cosigning key to use
+     * Either takes one argument:
+     * @param array $options
+     *
+     * Or takes three arguments (old, deprecated syntax):
+     * (@nonPHP-doc) @param      $identifier
+     * (@nonPHP-doc) @param      $password
+     * (@nonPHP-doc) @param int  $keyIndex         override for the blocktrail cosigning key to use
+     *
      * @return array[WalletInterface, (string)primaryMnemonic, (string)backupMnemonic]
      * @throws \Exception
      */
-    public function createNewWallet($identifier, $password, $keyIndex = 0);
+    public function createNewWallet($options);
 
     /**
      * create wallet using the API
@@ -267,12 +272,17 @@ interface BlocktrailSDKInterface {
     /**
      * initialize a previously created wallet
      *
-     * @param string    $identifier             the wallet identifier to be initialized
-     * @param string    $password               the password to decrypt the mnemonic with
+     * Either takes one argument:
+     * @param array $options
+     *
+     * Or takes two arguments (old, deprecated syntax):
+     * (@nonPHP-doc) @param string    $identifier             the wallet identifier to be initialized
+     * (@nonPHP-doc) @param string    $password               the password to decrypt the mnemonic with
+     *
      * @return WalletInterface
      * @throws \Exception
      */
-    public function initWallet($identifier, $password);
+    public function initWallet($options);
 
     /**
      * get the wallet data from the server


### PR DESCRIPTION
```php
$blocktrail->createNewWallet([
    "identifier" => "mycustomidentifier",
    "primary_private_key" => "xpriv...",
]);

$blocktrail->createNewWallet([
    "identifier" => "mycustomidentifier",
    "primary_mnemonic" => "my mnemonic should be strong",
    "passphrase" => "password",
    "store_primary_mnemonic" => false,
]);
```

had to redo the `initWallet` and `createNewWallet` to be able to accept more arguments, now takes an `array` instead, still supports old arguments through `func_get_args()` for BC