### PR TITLE
Update RestClient.php

### DIFF
--- a/src/Connection/RestClient.php
+++ b/src/Connection/RestClient.php
@@ -52,7 +52,7 @@ class RestClient {
                 ),
                 'exceptions' => false,
                 'connect_timeout' => 3,
-                'timeout' => 10.0, // tmp until we have a good matrix of all the requests and their expect min/max time
+                'timeout' => 60.0, // tmp until we have a good matrix of all the requests and their expect min/max time
                 'verify' => true,
                 'proxy' => '',
                 'debug' => false,


### PR DESCRIPTION
Some addresses take well over 10 seconds to get the transaction list, so this limitation was creating errors on my script. 60 seconds works for me. I have to lookup a lot of addresses from faucets (so thousands of transactions with hundreds of outputs and inputs each).