### PR TITLE
PHPECC: bump to v0.4.1 for wider compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-dom": "*",
 
         "bitwasp/bitcoin": "v0.0.30.2",
-        "mdanter/ecc": "v0.4.0",
+        "mdanter/ecc": "v0.4.1",
 
         "guzzlehttp/guzzle": "6.*",
         "99designs/http-signatures-guzzlehttp": "dev-master",


### PR DESCRIPTION
PHPECC v0.4.1 addresses https://github.com/blocktrail/blocktrail-sdk-php/issues/36 by allowing random_compat ^1|^2 for PHP5 & 7 support. 