### PR TITLE
Test project source is usable with various frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   # run tests when phpcs is not enabled
-  - export RUN_PHPUNIT=true
+  - export RUN_PHPUNIT="${RUN_PHPUNIT}:-true"
   - sh -c 'if [ "${PHPCS}" = "true" ]; then export RUN_PHPUNIT=false; fi'
   - sh -c 'if [ "${TEST_FRAMEWORK}" != "" ]; then export RUN_PHPUNIT=false; fi'
   - sh -c 'if [ "${RUN_PHPUNIT}" = "true" ]; then ./vendor/bin/phpunit -c ./phpunit.xml; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,21 @@ before_install:
 
 install:
   - composer update
+  - sh -c 'if [ "${TEST_FRAMEWORK}" != "" ]; then composer global require fxp/composer-asset-plugin; fi'
 
 script:
   # run tests when phpcs is not enabled
-  - sh -c 'if [ "${PHPCS}" != "true" ]; then ./vendor/bin/phpunit -c ./phpunit.xml; fi'
-  - sh -c 'if [ "${PHPCS}" != "true" ]; then ./vendor/bin/phpunit -c ./phpunit-recovery.xml; fi';
+  - export RUN_PHPUNIT=true
+  - sh -c 'if [ "${PHPCS}" = "true" ]; then export RUN_PHPUNIT=false; fi'
+  - sh -c 'if [ "${TEST_FRAMEWORK}" != "" ]; then export RUN_PHPUNIT=false; fi'
+  - sh -c 'if [ "${RUN_PHPUNIT}" = "true" ]; then ./vendor/bin/phpunit -c ./phpunit.xml; fi'
+  - sh -c 'if [ "${RUN_PHPUNIT}" = "true" ]; then ./vendor/bin/phpunit -c ./phpunit-recovery.xml; fi';
 
   # run phpcs when enabled
   - sh -c 'if [ "${PHPCS}" = "true" ]; then ./vendor/bin/phpcs --standard=./phpcs.xml -n ./src/ && echo "PHPCS OK"; fi'
+
+  # run framework tests when enabled
+  - sh -c 'if [ "${TEST_FRAMEWORK}" != "" ]; then php framework-test.php dev-${TRAVIS_PULL_REQUEST_BRANCH} && echo "Framework integration OK"; fi'
 
   # check coverage if report was generated (requires xdebug enabled)
   - sh -c 'if [ -e clover.xml ]; then php coverage-checker.php clover.xml 70; fi'
@@ -50,3 +57,7 @@ matrix:
     # php5.6 run with phpcs (won't run tests, only phpcs)
     - php: 5.6
       env: PHPCS=true WITH_XDEBUG=false
+    - php: 5.6
+      env: TEST_FRAMEWORK=true RUN_PHPUNIT=false
+    - php: 7.1
+      env: TEST_FRAMEWORK=true RUN_PHPUNIT=false

--- a/framework-test.php
+++ b/framework-test.php
@@ -1,0 +1,126 @@
+<?php
+
+$sdkTarget = '@dev';
+if ($argc > 1) {
+    $sdkTarget = $argv[1];
+}
+
+$builds = [
+    'codeigniter/framework' => [
+        '3.1.*', '3.0.*',
+    ],
+    'slim/slim' => [
+        '3.7.*', '3.6.*', '3.5.*', '3.4.*', '3.3.*', '3.2.*', '3.1.*', '3.0.*', '2.6.*',
+        '2.5.*', '2.4.*', '2.3.*'
+    ],
+    'laravel/framework' => [
+        '5.3.*', '5.2.*'
+    ],
+    'symfony/symfony' => [
+        '3.2.*', '3.1.*', '3.0.*', '2.8.*'
+    ],
+    'silex/silex' => [
+        '2.0.*', '1.3.*',
+    ],
+    'fuel/fuel' => [
+        '1.8.*'
+    ],
+    'yiisoft/yii' => [
+        '1.1.*'
+    ],
+    'yiisoft/yii2' => [
+        '2.0.*'
+    ],
+    'cakephp/cakephp' => [
+        '3.3.*', '3.2.*',
+    ]
+];
+
+function checkBuilds (array $builds) {
+  foreach ($builds as $framework => $listedVersions) {
+    if (!is_array($listedVersions)) {
+      error_log('MALFORMED FRAMEWORKS MATRIX');
+      exit(-1);
+    }
+  }
+}
+
+$outputLog = '';
+
+function runFrameworkTest($sdkTarget, $testFramework, $testFrameworkVersion)
+{
+
+    $framework = "{$testFramework} {$testFrameworkVersion}";
+
+    global $outputLog;
+  $composer = <<<EOF
+{
+  "name": "integration tester",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "../"
+    }
+  ],
+  "require": {
+    "$testFramework": "$testFrameworkVersion"
+  }
+}
+EOF;
+
+    mkdir('framework');
+    chdir('./framework');
+    file_put_contents('composer.json', $composer);
+
+    $returnCode = 0;
+    $output = [];
+    exec('composer install 2>&1', $output, $returnCode);
+    if ($returnCode !== 0) {
+        $outputLog .= "###################### Failure: Installing framework {$framework} ###################### \n\n" . implode("\n", $output);
+    } else {
+        $returnCode = 0;
+        $output = [];
+        exec('composer require blocktrail/blocktrail-sdk ' . $sdkTarget . ' 2>&1', $output, $returnCode);
+        if ($returnCode !== 0) {
+            $outputLog .= "###################### Failure: Installing SDK with {$framework} ###################### \n\n" . implode("\n", $output);
+        }
+    }
+
+    cleanup();
+
+    $ok = $returnCode === 0;
+    echo "Testing {$framework} - " . ($ok ? 'pass' : 'FAIL') . PHP_EOL;
+
+    return $ok;
+}
+
+function cleanup() {
+    chdir('..');
+    exec('rm -rf framework');
+}
+
+function build($sdkTarget, array $builds) {
+  checkBuilds($builds);
+  $results = [];
+  foreach ($builds as $framework => $testVersions) {
+    foreach ($testVersions as $testVersion) {
+      $results[$framework . ":" . $testVersion] = runFrameworkTest($sdkTarget, $framework, $testVersion);
+    }
+  }
+
+  $ok = true;
+  foreach ($results as $result) {
+    $ok = $ok && $result;
+  }
+
+  if (!$ok) {
+      global $outputLog;
+      echo "\nOutput log: \n\n";
+      echo $outputLog . PHP_EOL;
+      exit(-1);
+  }
+
+  exit(0);
+}
+
+build($sdkTarget, $builds);


### PR DESCRIPTION
This PR adds a tool to check that a pull-request hasn't impacted the compatibility of the SDK with a number of frameworks.

I've specified `[maj].[min].*` for a number of versions of each framework, the idea being we test the latest release from each minor release going forward, and see if anything conflicts as either set of dependencies change.

#### Currently testing

| Framework  | Version |
|-------------- | ------------- |
| slim      | 3.7.*  3.6.*  3.5.*  3.4.* 3.3.* 3.2.* 3.1.* 3.0.* 2.6.* | 
| laravel      | 5.3.* 5.2.*      | 
| symfony | 3.2.* 3.1.* 3.0.* 2.8.*      |    
| silex | 2.0.* 1.3.* |
| fuel | 1.8.* |
| yii | 1.1.* |
| yii2 | 2.0.* |
| cakephp | 3.3.* 3.2.* |