### PR TITLE
Bump BitcoinPHP to v0.0.31.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ext-gd": "*",
         "ext-dom": "*",
 
-        "bitwasp/bitcoin": "v0.0.30.2",
+        "bitwasp/bitcoin": "v0.0.31.2",
         "mdanter/ecc": "v0.4.1",
 
         "guzzlehttp/guzzle": "6.*",

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -9,6 +9,7 @@ use BitWasp\Bitcoin\MessageSigner\MessageSigner;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
@@ -900,7 +901,7 @@ abstract class Wallet implements WalletInterface {
 
             $key = $this->primaryPrivateKey->buildKey($path)->key()->getPrivateKey();
 
-            $signer->sign($idx, $key, $output, $redeemScript);
+            $signer->sign($idx, $key, $output, (new SignData())->p2sh($redeemScript));
         }
 
         return $signer->get();

--- a/src/WalletSweeper.php
+++ b/src/WalletSweeper.php
@@ -8,6 +8,7 @@ use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
@@ -379,8 +380,12 @@ abstract class WalletSweeper {
             $key = $this->primaryPrivateKey->buildKey($path)->key()->getPrivateKey();
             $backupKey = $this->backupPrivateKey->buildKey($path->unhardenedPath())->key()->getPrivateKey();
 
-            $signer->sign($idx, $key, $output, $redeemScript);
-            $signer->sign($idx, $backupKey, $output, $redeemScript);
+            $signData = new SignData();
+            $signData->p2sh($redeemScript);
+            $input = $signer->input($idx, $output, $signData);
+
+            $input->sign($key);
+            $input->sign($backupKey);
         }
 
         return $signer->get();


### PR DESCRIPTION
This version introduces the SignData structure, which cleans up the signing API (see WalletSweeper) The Validator class was removed in favor of using the `ConsensusInterface`