### PR TITLE
Bump php-aes-gcm dep: v1.0.0 -> v1.2.0. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "dompdf/dompdf" : "0.6.*",
         "endroid/qrcode": "1.5.*",
         "blocktrail/cryptojs-aes-php": "0.1.*",
-        "spomky-labs/php-aes-gcm": "v1.0.0"
+        "spomky-labs/php-aes-gcm": "v1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*",


### PR DESCRIPTION
https://github.com/Spomky-Labs/php-aes-gcm/compare/v1.0.0...v1.2.0

verified no dependency changes, just code cleaning and supporting openssl's API for AEAD (PHP7.1+). 

It also supports libCrypto (https://github.com/bukka/php-crypto) installable through pecl, so long as the dependency is available on the machine. It exposes much more than `ext-openssl`, but is installable from PHP5.3 up, so could recommend it to PHP 5.6-7.0 users. 

I had never heard of this extension before, we should spend some time reviewing/testing before telling people to use it. 