### PR TITLE
Use pack's unsigned char code, rather than signed

### DIFF
--- a/src/V3Crypt/Encryption.php
+++ b/src/V3Crypt/Encryption.php
@@ -71,7 +71,7 @@ class Encryption
             throw new \RuntimeException('IV must be exactly 16 bytes');
         }
 
-        $header = new Buffer(pack('c', $salt->getSize()) . $salt->getBinary() . pack('V', $iterations));
+        $header = new Buffer(pack('C', $salt->getSize()) . $salt->getBinary() . pack('V', $iterations));
 
         list ($ct, $tag) = AESGCM::encrypt(
             KeyDerivation::compute($pw, $salt, $iterations)->getBinary(),


### PR DESCRIPTION
Mostly harmless bugfix: saltLen is already pretty contrained at > 0 && <= 128, but nevertheless, we don't need to use the signed representation here.