### PR TITLE
Extract RestClient as an abstract class

### DIFF
--- a/src/BlocktrailSDK.php
+++ b/src/BlocktrailSDK.php
@@ -103,7 +103,7 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
         if ($network === "bitcoin") {
             if ($regtest) {
                 $useNetwork = NetworkFactory::bitcoinRegtest();
-            } if ($testnet) {
+            } else if ($testnet) {
                 $useNetwork = NetworkFactory::bitcoinTestnet();
             } else {
                 $useNetwork = NetworkFactory::bitcoin();

--- a/src/BlocktrailSDK.php
+++ b/src/BlocktrailSDK.php
@@ -27,6 +27,7 @@ use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Connection\RestClient;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\Connection\RestClientInterface;
 use Blocktrail\SDK\V3Crypt\Encryption;
 use Blocktrail\SDK\V3Crypt\EncryptionMnemonic;
 use Blocktrail\SDK\V3Crypt\KeyDerivation;
@@ -36,7 +37,7 @@ use Blocktrail\SDK\V3Crypt\KeyDerivation;
  */
 class BlocktrailSDK implements BlocktrailSDKInterface {
     /**
-     * @var Connection\RestClient
+     * @var Connection\RestClientInterface
      */
     protected $client;
 
@@ -142,10 +143,17 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
     }
 
     /**
-     * @return  RestClient
+     * @return  RestClientInterface
      */
     public function getRestClient() {
         return $this->client;
+    }
+
+    /**
+     * @param RestClientInterface $restClient
+     */
+    public function setRestClient(RestClientInterface $restClient) {
+        $this->client = $restClient;
     }
 
     /**

--- a/src/BlocktrailSDK.php
+++ b/src/BlocktrailSDK.php
@@ -101,18 +101,18 @@ class BlocktrailSDK implements BlocktrailSDKInterface {
     protected function setBitcoinLibMagicBytes($network, $testnet, $regtest) {
 
         if ($network === "bitcoin") {
-            if ($testnet) {
-                $useNetwork = NetworkFactory::bitcoinTestnet();
-            } else if ($regtest) {
+            if ($regtest) {
                 $useNetwork = NetworkFactory::bitcoinRegtest();
+            } if ($testnet) {
+                $useNetwork = NetworkFactory::bitcoinTestnet();
             } else {
                 $useNetwork = NetworkFactory::bitcoin();
             }
         } else if ($network === "bitcoincash") {
-            if ($testnet) {
-                $useNetwork = new BitcoinCashTestnet();
-            } else if ($regtest) {
+            if ($regtest) {
                 $useNetwork = new BitcoinCashRegtest();
+            } else if ($testnet) {
+                $useNetwork = new BitcoinCashTestnet();
             } else {
                 $useNetwork = new BitcoinCash();
             }

--- a/src/BlocktrailSDKInterface.php
+++ b/src/BlocktrailSDKInterface.php
@@ -2,7 +2,7 @@
 
 namespace Blocktrail\SDK;
 
-use Blocktrail\SDK\Connection\RestClient;
+use Blocktrail\SDK\Connection\BaseRestClient;
 
 /**
  * Interface BlocktrailSDK
@@ -39,7 +39,7 @@ interface BlocktrailSDKInterface {
     public function setCurlDefaultOption($key, $value);
 
     /**
-     * @return  RestClient
+     * @return  BaseRestClient
      */
     public function getRestClient();
 

--- a/src/Connection/BaseRestClient.php
+++ b/src/Connection/BaseRestClient.php
@@ -1,0 +1,271 @@
+<?PHP
+
+namespace Blocktrail\SDK\Connection;
+
+use Blocktrail\SDK\Connection\Exceptions\BannedIP;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use Blocktrail\SDK\Blocktrail;
+use Blocktrail\SDK\Connection\Exceptions\EndpointSpecificError;
+use Blocktrail\SDK\Connection\Exceptions\GenericServerError;
+use Blocktrail\SDK\Connection\Exceptions\ObjectNotFound;
+use Blocktrail\SDK\Connection\Exceptions\UnknownEndpointSpecificError;
+use Blocktrail\SDK\Connection\Exceptions\EmptyResponse;
+use Blocktrail\SDK\Connection\Exceptions\InvalidCredentials;
+use Blocktrail\SDK\Connection\Exceptions\MissingEndpoint;
+use Blocktrail\SDK\Connection\Exceptions\GenericHTTPError;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class BaseRestClient
+ *
+ */
+abstract class BaseRestClient implements RestClientInterface
+{
+
+    const AUTH_HTTP_SIG = 'http-signatures';
+
+    /**
+     * @var string
+     */
+    protected $apiKey;
+
+    /**
+     * @var string
+     */
+    protected $apiEndpoint;
+
+    /**
+     * @var string
+     */
+    protected $apiVersion;
+
+    /**
+     * @var string
+     */
+    protected $apiSecret;
+
+    /**
+     * @var bool
+     */
+    protected $verboseErrors = false;
+
+    /**
+     * @var array
+     */
+    protected static $replaceQuery = ['=' => '%3D', '&' => '%26'];
+
+    /**
+     * BaseRestClient constructor.
+     * @param string $apiEndpoint
+     * @param string $apiVersion
+     * @param string $apiKey
+     * @param string $apiSecret
+     */
+    public function __construct($apiEndpoint, $apiVersion, $apiKey, $apiSecret) {
+        $this->apiEndpoint = $apiEndpoint;
+        $this->apiVersion = $apiVersion;
+        $this->apiKey = $apiKey;
+        $this->apiSecret = $apiSecret;
+    }
+
+    /**
+     * @param Uri $uri
+     * @param string $key
+     * @return bool
+     */
+    public static function hasQueryValue(Uri $uri, $key) {
+        $current = $uri->getQuery();
+        $key = strtr($key, self::$replaceQuery);
+
+        if (!$current) {
+            $result = [];
+        } else {
+            $result = [];
+            foreach (explode('&', $current) as $part) {
+                if (explode('=', $part)[0] === $key) {
+                    return true;
+                };
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * enable verbose errors
+     *
+     * @param   bool        $verboseErrors
+     */
+    public function setVerboseErrors($verboseErrors = true) {
+        $this->verboseErrors = $verboseErrors;
+    }
+
+    /**
+     * @param   string          $endpointUrl
+     * @param   array           $queryString
+     * @param   string          $auth           http-signatures to enable http-signature signing
+     * @param   float           $timeout        timeout in seconds
+     * @return  Response
+     */
+    public function get($endpointUrl, $queryString = null, $auth = null, $timeout = null) {
+        return $this->request('GET', $endpointUrl, $queryString, null, $auth, null, $timeout);
+    }
+
+    /**
+     * @param   string          $endpointUrl
+     * @param   null            $queryString
+     * @param   array|string    $postData
+     * @param   string          $auth           http-signatures to enable http-signature signing
+     * @param   float           $timeout        timeout in seconds
+     * @return  Response
+     */
+    public function post($endpointUrl, $queryString = null, $postData = '', $auth = null, $timeout = null) {
+        return $this->request('POST', $endpointUrl, $queryString, $postData, $auth, null, $timeout);
+    }
+
+    /**
+     * @param   string          $endpointUrl
+     * @param   null            $queryString
+     * @param   array|string    $putData
+     * @param   string          $auth           http-signatures to enable http-signature signing
+     * @param   float           $timeout        timeout in seconds
+     * @return  Response
+     */
+    public function put($endpointUrl, $queryString = null, $putData = '', $auth = null, $timeout = null) {
+        return $this->request('PUT', $endpointUrl, $queryString, $putData, $auth, null, $timeout);
+    }
+
+    /**
+     * @param   string          $endpointUrl
+     * @param   null            $queryString
+     * @param   array|string    $postData
+     * @param   string          $auth           http-signatures to enable http-signature signing
+     * @param   float           $timeout        timeout in seconds
+     * @return  Response
+     */
+    public function delete($endpointUrl, $queryString = null, $postData = null, $auth = null, $timeout = null) {
+        return $this->request('DELETE', $endpointUrl, $queryString, $postData, $auth, 'url', $timeout);
+    }
+
+    /**
+     * generic request executor
+     *
+     * @param   string          $method         GET, POST, PUT, DELETE
+     * @param   string          $endpointUrl
+     * @param   array           $queryString
+     * @param   array|string    $body
+     * @param   string          $auth           http-signatures to enable http-signature signing
+     * @param   string          $contentMD5Mode body or url
+     * @param   float           $timeout        timeout in seconds
+     * @return Request
+     */
+    public function buildRequest($method, $endpointUrl, $queryString = null, $body = null, $auth = null, $contentMD5Mode = null, $timeout = null) {
+        if (is_null($contentMD5Mode)) {
+            $contentMD5Mode = !is_null($body) ? 'body' : 'url';
+        }
+
+        $request = new Request($method, $this->apiEndpoint . $endpointUrl);
+        $uri = $request->getUri();
+
+        if ($queryString) {
+            foreach ($queryString as $k => $v) {
+                $uri = Uri::withQueryValue($uri, $k, $v);
+            }
+        }
+
+        if (!self::hasQueryValue($uri, 'api_key')) {
+            $uri = Uri::withQueryValue($uri, 'api_key', $this->apiKey);
+        }
+
+        // normalize the query string the same way the server expects it
+        /** @var Request $request */
+        $request = $request->withUri($uri->withQuery(\Symfony\Component\HttpFoundation\Request::normalizeQueryString($uri->getQuery())));
+
+        if (!$request->hasHeader('Date')) {
+            $request = $request->withHeader('Date', $this->getRFC1123DateString());
+        }
+
+        if (!is_null($body)) {
+            if (!$request->hasHeader('Content-Type')) {
+                $request = $request->withHeader('Content-Type', 'application/json');
+            }
+
+            if (!is_string($body)) {
+                $body = json_encode($body);
+            }
+            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for($body));
+        }
+
+        // for GET/DELETE requests, MD5 the request URI (excludes domain, includes query strings)
+        if ($contentMD5Mode == 'body') {
+            $request = $request->withHeader('Content-MD5', md5((string)$body));
+        } else {
+            $request = $request->withHeader('Content-MD5', md5($request->getRequestTarget()));
+        }
+
+        return $request;
+    }
+
+    /**
+     * @param ResponseInterface $responseObj
+     * @return Response
+     * @throws BannedIP
+     * @throws EmptyResponse
+     * @throws EndpointSpecificError
+     * @throws GenericHTTPError
+     * @throws GenericServerError
+     * @throws InvalidCredentials
+     * @throws MissingEndpoint
+     * @throws ObjectNotFound
+     * @throws UnknownEndpointSpecificError
+     */
+    public function responseHandler(ResponseInterface $responseObj) {
+        $httpResponseCode = (int)$responseObj->getStatusCode();
+        $httpResponsePhrase = (string)$responseObj->getReasonPhrase();
+        $body = $responseObj->getBody();
+
+        if ($httpResponseCode == 200) {
+            if (!$body) {
+                throw new EmptyResponse(Blocktrail::EXCEPTION_EMPTY_RESPONSE, $httpResponseCode);
+            }
+
+            $result = new Response($httpResponseCode, $body);
+
+            return $result;
+        } elseif ($httpResponseCode == 400 || $httpResponseCode == 403) {
+            $data = json_decode($body, true);
+
+            if ($data && isset($data['msg'], $data['code'])) {
+                throw new EndpointSpecificError(!is_string($data['msg']) ? json_encode($data['msg']) : $data['msg'], $data['code']);
+            } else {
+                if (preg_match("/^banned( IP)? \[(.+)\]\n?$/", $body, $m)) {
+                    throw new BannedIP($m[2]);
+                }
+                throw new UnknownEndpointSpecificError($this->verboseErrors ? $body : Blocktrail::EXCEPTION_UNKNOWN_ENDPOINT_SPECIFIC_ERROR);
+            }
+        } elseif ($httpResponseCode == 401) {
+            throw new InvalidCredentials($this->verboseErrors ? $body : Blocktrail::EXCEPTION_INVALID_CREDENTIALS, $httpResponseCode);
+        } elseif ($httpResponseCode == 404) {
+            if ($httpResponsePhrase == "Endpoint Not Found") {
+                throw new MissingEndpoint($this->verboseErrors ? $body : Blocktrail::EXCEPTION_MISSING_ENDPOINT, $httpResponseCode);
+            } else {
+                throw new ObjectNotFound($this->verboseErrors ? $body : Blocktrail::EXCEPTION_OBJECT_NOT_FOUND, $httpResponseCode);
+            }
+        } elseif ($httpResponseCode == 500) {
+            throw new GenericServerError(Blocktrail::EXCEPTION_GENERIC_SERVER_ERROR . "\nServer Response: " . $body, $httpResponseCode);
+        } else {
+            throw new GenericHTTPError(Blocktrail::EXCEPTION_GENERIC_HTTP_ERROR . "\nServer Response: " . $body, $httpResponseCode);
+        }
+    }
+
+    /**
+     * Returns curent fate time in RFC1123 format, using UTC time zone
+     *
+     * @return  string
+     */
+    private function getRFC1123DateString() {
+        $date = new \DateTime(null, new \DateTimeZone("UTC"));
+        return str_replace("+0000", "GMT", $date->format(\DateTime::RFC1123));
+    }
+}

--- a/src/Connection/RestClient.php
+++ b/src/Connection/RestClient.php
@@ -1,59 +1,16 @@
-<?PHP
+<?php
 
 namespace Blocktrail\SDK\Connection;
 
-use Blocktrail\SDK\Connection\Exceptions\BannedIP;
+use Blocktrail\SDK\Blocktrail;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
 use HttpSignatures\Context;
-use Blocktrail\SDK\Blocktrail;
-use Blocktrail\SDK\Connection\Exceptions\EndpointSpecificError;
-use Blocktrail\SDK\Connection\Exceptions\GenericServerError;
-use Blocktrail\SDK\Connection\Exceptions\ObjectNotFound;
-use Blocktrail\SDK\Connection\Exceptions\UnknownEndpointSpecificError;
-use Blocktrail\SDK\Connection\Exceptions\EmptyResponse;
-use Blocktrail\SDK\Connection\Exceptions\InvalidCredentials;
-use Blocktrail\SDK\Connection\Exceptions\MissingEndpoint;
-use Blocktrail\SDK\Connection\Exceptions\GenericHTTPError;
 use HttpSignatures\GuzzleHttpSignatures;
-use Psr\Http\Message\ResponseInterface;
 
-/**
- * Class RestClient
- *
- */
-class RestClient {
-
-    const AUTH_HTTP_SIG = 'http-signatures';
-
-    /**
-     * @var Guzzle
-     */
-    protected $guzzle;
-
-    /**
-     * @var string
-     */
-    protected $apiKey;
-
-    /**
-     * @var string
-     */
-    protected $apiEndpoint;
-
-    /**
-     * @var string
-     */
-    protected $apiVersion;
-
-    /**
-     * @var string
-     */
-    protected $apiSecret;
-
+class RestClient extends BaseRestClient
+{
     /**
      * @var array
      */
@@ -65,16 +22,19 @@ class RestClient {
     protected $curlOptions = [];
 
     /**
-     * @var bool
+     * @var Guzzle
      */
-    protected $verboseErrors = false;
+    protected $guzzle;
 
+    /**
+     * GuzzleRestClient constructor.
+     * @param $apiEndpoint
+     * @param $apiVersion
+     * @param $apiKey
+     * @param $apiSecret
+     */
     public function __construct($apiEndpoint, $apiVersion, $apiKey, $apiSecret) {
-        $this->apiEndpoint = $apiEndpoint;
-        $this->apiVersion = $apiVersion;
-        $this->apiKey = $apiKey;
-        $this->apiSecret = $apiSecret;
-
+        parent::__construct($apiEndpoint, $apiVersion, $apiKey, $apiSecret);
         $this->guzzle = $this->createGuzzleClient();
     }
 
@@ -132,15 +92,7 @@ class RestClient {
         $this->guzzle = $this->createGuzzleClient();
     }
 
-    /**
-     * enable verbose errors
-     *
-     * @param   bool        $verboseErrors
-     */
-    public function setVerboseErrors($verboseErrors = true) {
-        $this->verboseErrors = $verboseErrors;
-    }
-        
+
     /**
      * set cURL default option on Guzzle client
      * @param string    $key
@@ -164,131 +116,6 @@ class RestClient {
     }
 
     /**
-     * @param   string          $endpointUrl
-     * @param   array           $queryString
-     * @param   string          $auth           http-signatures to enable http-signature signing
-     * @param   float           $timeout        timeout in seconds
-     * @return  Response
-     */
-    public function get($endpointUrl, $queryString = null, $auth = null, $timeout = null) {
-        return $this->request('GET', $endpointUrl, $queryString, null, $auth, null, $timeout);
-    }
-
-    /**
-     * @param   string          $endpointUrl
-     * @param   null            $queryString
-     * @param   array|string    $postData
-     * @param   string          $auth           http-signatures to enable http-signature signing
-     * @param   float           $timeout        timeout in seconds
-     * @return  Response
-     */
-    public function post($endpointUrl, $queryString = null, $postData = '', $auth = null, $timeout = null) {
-        return $this->request('POST', $endpointUrl, $queryString, $postData, $auth, null, $timeout);
-    }
-
-    /**
-     * @param   string          $endpointUrl
-     * @param   null            $queryString
-     * @param   array|string    $putData
-     * @param   string          $auth           http-signatures to enable http-signature signing
-     * @param   float           $timeout        timeout in seconds
-     * @return  Response
-     */
-    public function put($endpointUrl, $queryString = null, $putData = '', $auth = null, $timeout = null) {
-        return $this->request('PUT', $endpointUrl, $queryString, $putData, $auth, null, $timeout);
-    }
-
-    /**
-     * @param   string          $endpointUrl
-     * @param   null            $queryString
-     * @param   array|string    $postData
-     * @param   string          $auth           http-signatures to enable http-signature signing
-     * @param   float           $timeout        timeout in seconds
-     * @return  Response
-     */
-    public function delete($endpointUrl, $queryString = null, $postData = null, $auth = null, $timeout = null) {
-        return $this->request('DELETE', $endpointUrl, $queryString, $postData, $auth, 'url', $timeout);
-    }
-
-    private static $replaceQuery = ['=' => '%3D', '&' => '%26'];
-    public static function hasQueryValue(Uri $uri, $key) {
-        $current = $uri->getQuery();
-        $key = strtr($key, self::$replaceQuery);
-
-        if (!$current) {
-            $result = [];
-        } else {
-            $result = [];
-            foreach (explode('&', $current) as $part) {
-                if (explode('=', $part)[0] === $key) {
-                    return true;
-                };
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * generic request executor
-     *
-     * @param   string          $method         GET, POST, PUT, DELETE
-     * @param   string          $endpointUrl
-     * @param   array           $queryString
-     * @param   array|string    $body
-     * @param   string          $auth           http-signatures to enable http-signature signing
-     * @param   string          $contentMD5Mode body or url
-     * @param   float           $timeout        timeout in seconds
-     * @return Request
-     */
-    public function buildRequest($method, $endpointUrl, $queryString = null, $body = null, $auth = null, $contentMD5Mode = null, $timeout = null) {
-        if (is_null($contentMD5Mode)) {
-            $contentMD5Mode = !is_null($body) ? 'body' : 'url';
-        }
-
-        $request = new Request($method, $this->apiEndpoint . $endpointUrl);
-        $uri = $request->getUri();
-
-        if ($queryString) {
-            foreach ($queryString as $k => $v) {
-                $uri = Uri::withQueryValue($uri, $k, $v);
-            }
-        }
-
-        if (!self::hasQueryValue($uri, 'api_key')) {
-            $uri = Uri::withQueryValue($uri, 'api_key', $this->apiKey);
-        }
-
-        // normalize the query string the same way the server expects it
-        /** @var Request $request */
-        $request = $request->withUri($uri->withQuery(\Symfony\Component\HttpFoundation\Request::normalizeQueryString($uri->getQuery())));
-
-        if (!$request->hasHeader('Date')) {
-            $request = $request->withHeader('Date', $this->getRFC1123DateString());
-        }
-
-        if (!is_null($body)) {
-            if (!$request->hasHeader('Content-Type')) {
-                $request = $request->withHeader('Content-Type', 'application/json');
-            }
-
-            if (!is_string($body)) {
-                $body = json_encode($body);
-            }
-            $request = $request->withBody(\GuzzleHttp\Psr7\stream_for($body));
-        }
-
-        // for GET/DELETE requests, MD5 the request URI (excludes domain, includes query strings)
-        if ($contentMD5Mode == 'body') {
-            $request = $request->withHeader('Content-MD5', md5((string)$body));
-        } else {
-            $request = $request->withHeader('Content-MD5', md5($request->getRequestTarget()));
-        }
-
-        return $request;
-    }
-
-    /**
      * generic request executor
      *
      * @param   string          $method         GET, POST, PUT, DELETE
@@ -301,59 +128,9 @@ class RestClient {
      * @return Response
      */
     public function request($method, $endpointUrl, $queryString = null, $body = null, $auth = null, $contentMD5Mode = null, $timeout = null) {
-        $request = $this->buildRequest($method, $endpointUrl, $queryString, $body, $auth, $contentMD5Mode);
+        $request = $this->buildRequest($method, $endpointUrl, $queryString, $body, $auth, $contentMD5Mode, $timeout);
         $response = $this->guzzle->send($request, ['auth' => $auth, 'timeout' => $timeout]);
 
         return $this->responseHandler($response);
-    }
-
-    public function responseHandler(ResponseInterface $responseObj) {
-        $httpResponseCode = (int)$responseObj->getStatusCode();
-        $httpResponsePhrase = (string)$responseObj->getReasonPhrase();
-        $body = $responseObj->getBody();
-
-        if ($httpResponseCode == 200) {
-            if (!$body) {
-                throw new EmptyResponse(Blocktrail::EXCEPTION_EMPTY_RESPONSE, $httpResponseCode);
-            }
-
-            $result = new Response($httpResponseCode, $body);
-
-            return $result;
-        } elseif ($httpResponseCode == 400 || $httpResponseCode == 403) {
-            $data = json_decode($body, true);
-
-            if ($data && isset($data['msg'], $data['code'])) {
-                throw new EndpointSpecificError(!is_string($data['msg']) ? json_encode($data['msg']) : $data['msg'], $data['code']);
-            } else {
-                if (preg_match("/^banned( IP)? \[(.+)\]\n?$/", $body, $m)) {
-                    throw new BannedIP($m[2]);
-                }
-
-                throw new UnknownEndpointSpecificError($this->verboseErrors ? $body : Blocktrail::EXCEPTION_UNKNOWN_ENDPOINT_SPECIFIC_ERROR);
-            }
-        } elseif ($httpResponseCode == 401) {
-            throw new InvalidCredentials($this->verboseErrors ? $body : Blocktrail::EXCEPTION_INVALID_CREDENTIALS, $httpResponseCode);
-        } elseif ($httpResponseCode == 404) {
-            if ($httpResponsePhrase == "Endpoint Not Found") {
-                throw new MissingEndpoint($this->verboseErrors ? $body : Blocktrail::EXCEPTION_MISSING_ENDPOINT, $httpResponseCode);
-            } else {
-                throw new ObjectNotFound($this->verboseErrors ? $body : Blocktrail::EXCEPTION_OBJECT_NOT_FOUND, $httpResponseCode);
-            }
-        } elseif ($httpResponseCode == 500) {
-            throw new GenericServerError(Blocktrail::EXCEPTION_GENERIC_SERVER_ERROR . "\nServer Response: " . $body, $httpResponseCode);
-        } else {
-            throw new GenericHTTPError(Blocktrail::EXCEPTION_GENERIC_HTTP_ERROR . "\nServer Response: " . $body, $httpResponseCode);
-        }
-    }
-
-    /**
-     * Returns curent fate time in RFC1123 format, using UTC time zone
-     *
-     * @return  string
-     */
-    private function getRFC1123DateString() {
-        $date = new \DateTime(null, new \DateTimeZone("UTC"));
-        return str_replace("+0000", "GMT", $date->format(\DateTime::RFC1123));
     }
 }

--- a/src/Connection/RestClientInterface.php
+++ b/src/Connection/RestClientInterface.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Blocktrail\SDK\Connection;
+
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
+
+interface RestClientInterface
+{
+
+    /**
+     * enable verbose errors
+     *
+     * @param   bool $verboseErrors
+     */
+    public function setVerboseErrors($verboseErrors = true);
+
+    /**
+     * @param   string $endpointUrl
+     * @param   array $queryString
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   float $timeout timeout in seconds
+     * @return  Response
+     */
+    public function get($endpointUrl, $queryString = null, $auth = null, $timeout = null);
+
+    /**
+     * @param   string $endpointUrl
+     * @param   null $queryString
+     * @param   array|string $postData
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   float $timeout timeout in seconds
+     * @return  Response
+     */
+    public function post($endpointUrl, $queryString = null, $postData = '', $auth = null, $timeout = null);
+
+    /**
+     * @param   string $endpointUrl
+     * @param   null $queryString
+     * @param   array|string $putData
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   float $timeout timeout in seconds
+     * @return  Response
+     */
+    public function put($endpointUrl, $queryString = null, $putData = '', $auth = null, $timeout = null);
+
+    /**
+     * @param   string $endpointUrl
+     * @param   null $queryString
+     * @param   array|string $postData
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   float $timeout timeout in seconds
+     * @return  Response
+     */
+    public function delete($endpointUrl, $queryString = null, $postData = null, $auth = null, $timeout = null);
+
+    /**
+     * generic request executor
+     *
+     * @param   string $method GET, POST, PUT, DELETE
+     * @param   string $endpointUrl
+     * @param   array $queryString
+     * @param   array|string $body
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   string $contentMD5Mode body or url
+     * @param   float $timeout timeout in seconds
+     * @return Request
+     */
+    public function buildRequest($method, $endpointUrl, $queryString = null, $body = null, $auth = null, $contentMD5Mode = null, $timeout = null);
+
+    /**
+     * generic request executor
+     *
+     * @param   string $method GET, POST, PUT, DELETE
+     * @param   string $endpointUrl
+     * @param   array $queryString
+     * @param   array|string $body
+     * @param   string $auth http-signatures to enable http-signature signing
+     * @param   string $contentMD5Mode body or url
+     * @param   float $timeout timeout in seconds
+     * @return Response
+     */
+    public function request($method, $endpointUrl, $queryString = null, $body = null, $auth = null, $contentMD5Mode = null, $timeout = null);
+
+    public function responseHandler(ResponseInterface $responseObj);
+}

--- a/src/Network/AbstractBitcoinCash.php
+++ b/src/Network/AbstractBitcoinCash.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Blocktrail\SDK\Network;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+
+abstract class AbstractBitcoinCash extends Network implements BitcoinCashNetworkInterface
+{
+    /**
+     * @var string
+     */
+    private $cashAddressPrefix;
+
+    /**
+     * BitcoinCash constructor.
+     * @param NetworkInterface $base
+     * @param string $cashAddressPrefix
+     * @throws \Exception
+     */
+    public function __construct(NetworkInterface $base, $cashAddressPrefix) {
+        parent::__construct(
+            $base->getAddressByte(),
+            $base->getP2shByte(),
+            $base->getPrivByte(),
+            $base->isTestnet()
+        );
+
+        $this->setHDPrivByte($base->getHDPrivByte());
+        $this->setHDPubByte($base->getHDPubByte());
+        $this->setNetMagicBytes($base->getNetMagicBytes());
+        $this->cashAddressPrefix = $cashAddressPrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCashAddressPrefix() {
+        return $this->cashAddressPrefix;
+    }
+}

--- a/src/Network/BitcoinCashRegtest.php
+++ b/src/Network/BitcoinCashRegtest.php
@@ -4,13 +4,13 @@ namespace Blocktrail\SDK\Network;
 
 use BitWasp\Bitcoin\Network\NetworkFactory;
 
-class BitcoinCash extends AbstractBitcoinCash
+class BitcoinCashRegtest extends AbstractBitcoinCash
 {
     /**
      * BitcoinCash constructor.
      * @throws \Exception
      */
     public function __construct() {
-        parent::__construct(NetworkFactory::bitcoin(), "bitcoincash");
+        parent::__construct(NetworkFactory::bitcoinRegtest(), "bchreg");
     }
 }

--- a/src/Network/BitcoinCashTestnet.php
+++ b/src/Network/BitcoinCashTestnet.php
@@ -4,13 +4,13 @@ namespace Blocktrail\SDK\Network;
 
 use BitWasp\Bitcoin\Network\NetworkFactory;
 
-class BitcoinCash extends AbstractBitcoinCash
+class BitcoinCashTestnet extends AbstractBitcoinCash
 {
     /**
      * BitcoinCash constructor.
      * @throws \Exception
      */
     public function __construct() {
-        parent::__construct(NetworkFactory::bitcoin(), "bitcoincash");
+        parent::__construct(NetworkFactory::bitcoinTestnet(), "bchtest");
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -37,6 +37,10 @@ abstract class Util {
             // Regtest is magic
             $apiNetwork = "rBTC";
             $testnet = true;
+        } else if ($network === "RBCC") {
+            // Regtest is magic
+            $apiNetwork = "rBCC";
+            $testnet = true;
         } else {
             // Default to bitcoin if they make no sense.
             $apiNetwork = "BTC";
@@ -80,6 +84,12 @@ abstract class Util {
             case 'rbtc':
             case 'bitcoin-regtest':
                 $network = 'bitcoin';
+                $testnet = true;
+                break;
+
+            case 'rbcc':
+            case 'bitcoincash-regtest':
+                $network = 'bitcoincash';
                 $testnet = true;
                 break;
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -37,9 +37,9 @@ abstract class Util {
             // Regtest is magic
             $apiNetwork = "rBTC";
             $testnet = true;
-        } else if ($network === "RBCC") {
+        } else if ($network === "RBCH") {
             // Regtest is magic
-            $apiNetwork = "rBCC";
+            $apiNetwork = "rBCH";
             $testnet = true;
         } else {
             // Default to bitcoin if they make no sense.
@@ -71,10 +71,12 @@ abstract class Util {
                 $testnet = true;
                 break;
             case 'bcc':
+            case 'bch':
             case 'bitcoincash':
                 $network = 'bitcoincash';
                 break;
 
+            case 'tbch':
             case 'tbcc':
             case 'bitcoincash-testnet':
                 $network = 'bitcoincash';
@@ -87,7 +89,7 @@ abstract class Util {
                 $testnet = true;
                 break;
 
-            case 'rbcc':
+            case 'rbch':
             case 'bitcoincash-regtest':
                 $network = 'bitcoincash';
                 $testnet = true;

--- a/src/Util.php
+++ b/src/Util.php
@@ -59,6 +59,7 @@ abstract class Util {
      * @throws \Exception
      */
     public static function normalizeNetwork($network, $testnet) {
+        $regtest = false;
         switch (strtolower($network)) {
             case 'btc':
             case 'bitcoin':
@@ -87,12 +88,14 @@ abstract class Util {
             case 'bitcoin-regtest':
                 $network = 'bitcoin';
                 $testnet = true;
+                $regtest = true;
                 break;
 
             case 'rbch':
             case 'bitcoincash-regtest':
                 $network = 'bitcoincash';
                 $testnet = true;
+                $regtest = true;
                 break;
 
             default:
@@ -100,7 +103,7 @@ abstract class Util {
             // this comment silences a phpcs error.
         }
 
-        return [$network, $testnet];
+        return [$network, $testnet, $regtest];
     }
 
     public static function arrayMapWithIndex(callable $fn, $arr) {

--- a/src/WalletSweeper.php
+++ b/src/WalletSweeper.php
@@ -94,9 +94,9 @@ abstract class WalletSweeper {
      */
     public function __construct(BufferInterface $primarySeed, BufferInterface $backupSeed, array $blocktrailPublicKeys, UnspentOutputFinder $utxoFinder, $network = 'btc', $testnet = false) {
         // normalize network and set bitcoinlib to the right magic-bytes
-        list($this->network, $this->testnet) = $this->normalizeNetwork($network, $testnet);
+        list($this->network, $this->testnet, $regtest) = $this->normalizeNetwork($network, $testnet);
 
-        $this->setBitcoinLibMagicBytes($this->network, $this->testnet);
+        $this->setBitcoinLibMagicBytes($this->network, $this->testnet,$regtest);
         $this->addressReader = $this->makeAddressReader([
             "use_cashaddress" => false,
         ]);
@@ -137,18 +137,18 @@ abstract class WalletSweeper {
     protected function setBitcoinLibMagicBytes($network, $testnet, $regtest) {
         assert($network == "bitcoin" || $network == "bitcoincash");
         if ($network === "bitcoin") {
-            if ($testnet) {
-                $useNetwork = NetworkFactory::bitcoinTestnet();
-            } if ($regtest) {
+            if ($regtest) {
                 $useNetwork = NetworkFactory::bitcoinRegtest();
+            } else if ($testnet) {
+                $useNetwork = NetworkFactory::bitcoinTestnet();
             } else {
                 $useNetwork = NetworkFactory::bitcoin();
             }
         } else if ($network === "bitcoincash") {
-            if ($testnet) {
-                $useNetwork = new BitcoinCashTestnet();
-            } if ($regtest) {
+            if ($regtest) {
                 $useNetwork = new BitcoinCashRegtest();
+            } else if ($testnet) {
+                $useNetwork = new BitcoinCashTestnet();
             } else {
                 $useNetwork = new BitcoinCash();
             }

--- a/src/WalletSweeper.php
+++ b/src/WalletSweeper.php
@@ -96,7 +96,7 @@ abstract class WalletSweeper {
         // normalize network and set bitcoinlib to the right magic-bytes
         list($this->network, $this->testnet, $regtest) = $this->normalizeNetwork($network, $testnet);
 
-        $this->setBitcoinLibMagicBytes($this->network, $this->testnet,$regtest);
+        $this->setBitcoinLibMagicBytes($this->network, $this->testnet, $regtest);
         $this->addressReader = $this->makeAddressReader([
             "use_cashaddress" => false,
         ]);

--- a/src/WalletSweeper.php
+++ b/src/WalletSweeper.php
@@ -26,6 +26,7 @@ use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Bitcoin\BIP32Path;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\Network\BitcoinCashRegtest;
 
 abstract class WalletSweeper {
 
@@ -133,16 +134,24 @@ abstract class WalletSweeper {
      * @param $network
      * @param $testnet
      */
-    protected function setBitcoinLibMagicBytes($network, $testnet) {
+    protected function setBitcoinLibMagicBytes($network, $testnet, $regtest) {
         assert($network == "bitcoin" || $network == "bitcoincash");
         if ($network === "bitcoin") {
             if ($testnet) {
                 $useNetwork = NetworkFactory::bitcoinTestnet();
+            } if ($regtest) {
+                $useNetwork = NetworkFactory::bitcoinRegtest();
             } else {
                 $useNetwork = NetworkFactory::bitcoin();
             }
         } else if ($network === "bitcoincash") {
-            $useNetwork = new BitcoinCash((bool) $testnet);
+            if ($testnet) {
+                $useNetwork = new BitcoinCashTestnet();
+            } if ($regtest) {
+                $useNetwork = new BitcoinCashRegtest();
+            } else {
+                $useNetwork = new BitcoinCash();
+            }
         }
 
         Bitcoin::setNetwork($useNetwork);

--- a/tests/BitcoinCashAddressTest.php
+++ b/tests/BitcoinCashAddressTest.php
@@ -4,15 +4,16 @@ namespace Blocktrail\SDK\Tests;
 
 
 use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Bitcoin;
 use Blocktrail\SDK\Address\BitcoinCashAddressReader;
 use Blocktrail\SDK\Address\CashAddress;
-use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\Network\BitcoinCashTestnet;
 
 class BitcoinCashAddressTest extends BlocktrailTestCase
 {
     public function testInitializeWithDefaultFormat() {
         $isTestnet = true;
-        $tbcc = new BitcoinCash($isTestnet);
+        $tbcc = new BitcoinCashTestnet();
         $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
         $legacyAddressWallet = $client->initWallet([
             "identifier" => "unittest-transaction",
@@ -40,7 +41,7 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
 
     public function testCurrentDefaultIsOldFormat() {
         $isTestnet = true;
-        $tbcc = new BitcoinCash($isTestnet);
+        $tbcc = new BitcoinCashTestnet();
 
         $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
         $cashAddrWallet = $client->initWallet([
@@ -57,7 +58,7 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
 
     public function testCanOptIntoNewAddressFormat() {
         $isTestnet = true;
-        $tbcc = new BitcoinCash($isTestnet);
+        $tbcc = new BitcoinCashTestnet();
 
         $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
         $cashAddrWallet = $client->initWallet([
@@ -75,7 +76,7 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
     public function testCanCoinSelectNewCashAddresses()
     {
         $isTestnet = true;
-        $network = new BitcoinCash($isTestnet);
+        $tbcc = new BitcoinCashTestnet();
         $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
         $cashAddrWallet = $client->initWallet([
             "identifier" => "unittest-transaction",
@@ -84,10 +85,10 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
         ]);
 
         $str = "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu";
-        $cashaddr = $cashAddrWallet->getAddressReader()->fromString($str, $network);
+        $cashaddr = $cashAddrWallet->getAddressReader()->fromString($str, $tbcc);
 
         $selection = $cashAddrWallet->coinSelection([
-             $cashaddr->getAddress($network) => 1234123,
+             $cashaddr->getAddress($tbcc) => 1234123,
         ], false);
 
         $this->assertArrayHasKey('utxos', $selection);

--- a/tests/BlocktrailSDKTest.php
+++ b/tests/BlocktrailSDKTest.php
@@ -2,7 +2,7 @@
 
 namespace Blocktrail\SDK\Tests;
 
-use Blocktrail\SDK\Connection\RestClient;
+use Blocktrail\SDK\Connection\RestClientInterface;
 use Blocktrail\SDK\BlocktrailSDK;
 use Blocktrail\SDK\Connection\Exceptions\InvalidCredentials;
 
@@ -10,7 +10,7 @@ class BlocktrailSDKTest extends BlocktrailTestCase
 {
     public function testRestClient() {
         $client = $this->setupBlocktrailSDK();
-        $this->assertTrue($client->getRestClient() instanceof RestClient);
+        $this->assertTrue($client->getRestClient() instanceof RestClientInterface);
     }
 
     public function testUpgradeKeyIndex() {

--- a/tests/Network/BitcoinCashTest.php
+++ b/tests/Network/BitcoinCashTest.php
@@ -6,6 +6,7 @@ use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Buffertools\Buffer;
 use Blocktrail\SDK\Address\CashAddress;
 use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\Network\BitcoinCashTestnet;
 
 class BitcoinCashTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +24,12 @@ class BitcoinCashTest extends \PHPUnit_Framework_TestCase
      */
     public function testBitcoinCash($testnet, $cashAddrPrefix)
     {
-        $network = new BitcoinCash($testnet);
+        if ($testnet) {
+            $network = new BitcoinCashTestnet();
+        } else {
+            $network = new BitcoinCash();
+        }
+
         $this->assertEquals($testnet, $network->isTestnet());
         $this->assertEquals($cashAddrPrefix, $network->getCashAddressPrefix());
 
@@ -51,7 +57,12 @@ class BitcoinCashTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoBech32($testnet)
     {
-        $network = new BitcoinCash($testnet);
+        if ($testnet) {
+            $network = new BitcoinCashTestnet();
+        } else {
+            $network = new BitcoinCash();
+        }
+
         $network->getSegwitBech32Prefix();
     }
 
@@ -77,7 +88,12 @@ class BitcoinCashTest extends \PHPUnit_Framework_TestCase
      */
     public function testCashAddress($testnet, $type, $hashHex, $expected)
     {
-        $network = new BitcoinCash($testnet);
+        if ($testnet) {
+            $network = new BitcoinCashTestnet();
+        } else {
+            $network = new BitcoinCash();
+        }
+
         $hash = Buffer::hex($hashHex);
         $addr = new CashAddress($type, $hash);
         $this->assertEquals($type, $addr->getType());

--- a/tests/OutputsNormalizerTest.php
+++ b/tests/OutputsNormalizerTest.php
@@ -8,6 +8,7 @@ use Blocktrail\SDK\Address\BitcoinCashAddressReader;
 use Blocktrail\SDK\Blocktrail;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\Network\BitcoinCashTestnet;
 use Blocktrail\SDK\OutputsNormalizer;
 
 class OutputsNormalizerTest extends BlocktrailTestCase
@@ -21,7 +22,13 @@ class OutputsNormalizerTest extends BlocktrailTestCase
                 return [NetworkFactory::bitcoin(), new BitcoinAddressReader()];
                 break;
             case "BCC":
-                return [new BitcoinCash($testnet), new BitcoinCashAddressReader(true)];
+                if ($testnet) {
+                    $network = new BitcoinCashTestnet();
+                } else {
+                    $network = new BitcoinCash();
+                }
+
+                return [$network, new BitcoinCashAddressReader(true)];
                 break;
             default:
                 throw new \RuntimeException("Unknown network");

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -19,6 +19,7 @@ class UtilTest extends BlocktrailTestCase
 
             ['RBTC', false, 'rBTC', true],
             ['RBTC', true, 'rBTC', true],
+            ['RBCH', true, 'rBCH', true],
 
             ['TBCC', false, 'tBCC', true],
             ['TBCC', true, 'tBCC', true],


### PR DESCRIPTION
Added a GuzzleRestClient / RestClientInterface, and it's now possible to override the default implementation in BlocktrailSDK - opening for consideration for now, have to look elsewhere for usage!

Might also be useful for testing the SDK itself. We could have a TestRestClient which takes a list of [$expectedRequestKeyVals, $expectedResponseKeyVals], and then build the key-value sets such that they exercise most of the code in the SDK without doing HTTP requests. 

Might be able to write a testing adapter which follows up by testing the HTTP request and response against the expected key-values.