### PR TITLE
[WIP] Coin Selection: allow DONTSIGN inputs

### DIFF
--- a/src/SignInfo.php
+++ b/src/SignInfo.php
@@ -4,9 +4,21 @@ namespace Blocktrail\SDK;
 
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 
 class SignInfo {
 
+    const MODE_DONTSIGN = 'dont_sign';
+    const MODE_SIGN = 'sign';
+
+    /**
+     * @var string
+     */
+    public $mode;
+
+    /**
+     * @var string
+     */
     public $path;
 
     /**
@@ -19,10 +31,27 @@ class SignInfo {
      */
     public $output;
 
+    /**
+     * SignInfo constructor.
+     * @param TransactionOutput $output
+     * @param string $mode
+     * @param string|null $path
+     * @param ScriptInterface|null $redeemScript
+     * @throws BlocktrailSDKException
+     */
+    public function __construct(TransactionOutput $output, $mode, $path = null, ScriptInterface $redeemScript = null) {
+        if ($mode === self::MODE_SIGN) {
+            if (null === $path) {
+                throw new BlocktrailSDKException("No path provided for {$mode} SignInfo");
+            }
+            if (!($redeemScript instanceof ScriptInterface)) {
+                throw new BlocktrailSDKException("No redeemScript provided for {$mode} SignInfo");
+            }
+        }
 
-    public function __construct($path, ScriptInterface $redeemScript, TransactionOutput $output) {
+        $this->output = $output;
+        $this->mode = $mode;
         $this->path = $path;
         $this->redeemScript = $redeemScript;
-        $this->output = $output;
     }
 }

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -4,7 +4,6 @@ namespace Blocktrail\SDK;
 
 use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Address\AddressInterface;
-use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Buffertools\Buffer;
@@ -51,7 +50,7 @@ class TransactionBuilder {
      * @param ScriptInterface|string $redeemScript           when NULL we'll use the path to determine the redeemscript
      * @return $this
      */
-    public function spendOutput($txId, $index, $value = null, $address = null, $scriptPubKey = null, $path = null, $redeemScript = null) {
+    public function spendOutput($txId, $index, $value = null, $address = null, $scriptPubKey = null, $path = null, $redeemScript = null, $signMode = SignInfo::MODE_SIGN) {
         $address = $address instanceof AddressInterface ? $address : AddressFactory::fromString($address);
         $scriptPubKey = ($scriptPubKey instanceof ScriptInterface)
             ? $scriptPubKey
@@ -60,7 +59,7 @@ class TransactionBuilder {
             ? $redeemScript
             : (ctype_xdigit($redeemScript) ? ScriptFactory::fromHex($redeemScript) : null);
 
-        $this->utxos[] = new UTXO($txId, $index, $value, $address, $scriptPubKey, $path, $redeemScript);
+        $this->utxos[] = new UTXO($txId, $index, $value, $address, $scriptPubKey, $path, $redeemScript, $signMode);
 
         return $this;
     }

--- a/src/UTXO.php
+++ b/src/UTXO.php
@@ -4,6 +4,7 @@ namespace Blocktrail\SDK;
 
 use BitWasp\Bitcoin\Address\AddressInterface;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Transaction\TransactionOutput;
 
 class UTXO {
 
@@ -27,7 +28,23 @@ class UTXO {
      */
     public $redeemScript;
 
-    public function __construct($hash, $index, $value = null, AddressInterface $address = null, ScriptInterface $scriptPubKey = null, $path = null, ScriptInterface $redeemScript = null) {
+    /**
+     * @var string
+     */
+    public $signMode;
+
+    /**
+     * UTXO constructor.
+     * @param $hash
+     * @param $index
+     * @param null $value
+     * @param AddressInterface|null $address
+     * @param ScriptInterface|null $scriptPubKey
+     * @param null $path
+     * @param ScriptInterface|null $redeemScript
+     * @param string $signMode
+     */
+    public function __construct($hash, $index, $value = null, AddressInterface $address = null, ScriptInterface $scriptPubKey = null, $path = null, ScriptInterface $redeemScript = null, $signMode = SignInfo::MODE_SIGN) {
         $this->hash = $hash;
         $this->index = $index;
         $this->value = $value;
@@ -35,5 +52,13 @@ class UTXO {
         $this->scriptPubKey = $scriptPubKey;
         $this->path = $path;
         $this->redeemScript = $redeemScript;
+        $this->signMode = $signMode;
+    }
+
+    /**
+     * @return SignInfo
+     */
+    public function getSignInfo() {
+        return new SignInfo(new TransactionOutput($this->value, $this->scriptPubKey), $this->signMode, $this->path, $this->redeemScript);
     }
 }


### PR DESCRIPTION
The SDK now accepts inputs from blocktrail which are marked 'dont_sign'.
These are counted towards the desired output value, and only included IFF
the input contributes it's at least the fee required to spend (making the
operation free for the user)