### PR TITLE
Bitcoin cash address format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-curl": "*",
 
         "bitwasp/bitcoin": "v0.0.34.1",
-        "btccom/cashaddr": "v0.0.3",
+        "btccom/cashaddress": "v0.0.3",
         "mdanter/ecc": "v0.4.*",
 
         "guzzlehttp/guzzle": "6.*",

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-curl": "*",
 
         "bitwasp/bitcoin": "v0.0.34.1",
+        "btccom/cashaddr": "v0.0.3",
         "mdanter/ecc": "v0.4.*",
 
         "guzzlehttp/guzzle": "6.*",

--- a/examples/custom_tx_payment_api_example.php
+++ b/examples/custom_tx_payment_api_example.php
@@ -5,7 +5,6 @@ use Blocktrail\SDK\Connection\Exceptions\ObjectNotFound;
 use Blocktrail\SDK\TransactionBuilder;
 use Blocktrail\SDK\UTXO;
 use Blocktrail\SDK\Wallet;
-use Blocktrail\SDK\WalletInterface;
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
@@ -29,6 +28,8 @@ try {
     $wallet->doDiscovery();
 }
 
+$addressReader = $wallet->getAddressReader();
+
 /*
  * custom created TX using the TransactionBuilder class,
  *  in this example we substract the fee required from the amount send
@@ -36,7 +37,7 @@ try {
  */
 
 $amount = BlocktrailSDK::toSatoshi(0.001);
-$paymentAddress = $wallet->getNewAddress();
+$paymentAddress = $addressReader->fromString($wallet->getNewAddress());
 
 // uncomment to create a couple of 0.001 BTC UTXOs (and 1 big output remains)
 //  after doing this run the example twice and the 2nd time around you can see it only using a single UTXO
@@ -55,7 +56,7 @@ $paymentAddress = $wallet->getNewAddress();
 $optimalFeePerKB = $wallet->getOptimalFeePerKB();
 $lowPriorityFeePerKB = $wallet->getLowPriorityFeePerKB();
 
-$txBuilder = new TransactionBuilder();
+$txBuilder = new TransactionBuilder($addressReader);
 $txBuilder->addRecipient($paymentAddress, $amount);
 
 // get coinselection for the payment we want to make

--- a/examples/custom_tx_payment_api_example_force_from.php
+++ b/examples/custom_tx_payment_api_example_force_from.php
@@ -43,7 +43,7 @@ $optimalFeePerKB = $wallet->getOptimalFeePerKB();
 $lowPriorityFeePerKB = $wallet->getLowPriorityFeePerKB();
 
 // setup txbuilder
-$txBuilder = new TransactionBuilder();
+$txBuilder = new TransactionBuilder($wallet->getAddressReader());
 // set send info
 $txBuilder->addRecipient($paymentAddress, $amount);
 // set change address to our sending address

--- a/examples/op_return_payment_api_example.php
+++ b/examples/op_return_payment_api_example.php
@@ -41,7 +41,7 @@ try {
 // $utxo = $utxos[array_rand($utxos)];
 
 $txBuilder = new TransactionBuilder();
-$txBuilder->addRecipient($wallet->getNewAddress(), Blocktrail::DUST + 1);
+$txBuilder->addRecipient(AddressFactory::fromString($wallet->getNewAddress()), Blocktrail::DUST + 1);
 $txBuilder->addOpReturn("TO DAAAA MOOOON@!的");
 
 $txBuilder = $wallet->coinSelectionForTxBuilder($txBuilder);

--- a/src/Address/AddressReaderBase.php
+++ b/src/Address/AddressReaderBase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Blocktrail\SDK\Address;
+
+use BitWasp\Bitcoin\Address\AddressInterface;
+use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Address\SegwitAddress;
+use BitWasp\Bitcoin\Base58;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\SegwitBech32;
+use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
+
+abstract class AddressReaderBase
+{
+    /**
+     * @param string $strAddress
+     * @param NetworkInterface $network
+     * @return PayToPubKeyHashAddress|ScriptHashAddress|null
+     */
+    protected function readBase58($strAddress, NetworkInterface $network) {
+        try {
+            $data = Base58::decodeCheck($strAddress);
+            $prefixByte = $data->slice(0, 1)->getHex();
+
+            if ($prefixByte === $network->getP2shByte()) {
+                return new ScriptHashAddress($data->slice(1));
+            } else if ($prefixByte === $network->getAddressByte()) {
+                return new PayToPubKeyHashAddress($data->slice(1));
+            }
+        } catch (\Exception $e) {
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $strAddress
+     * @param NetworkInterface $network
+     * @return SegwitAddress|null
+     */
+    protected function readBech32($strAddress, NetworkInterface $network) {
+        try {
+            return new SegwitAddress(SegwitBech32::decode($strAddress, $network));
+        } catch (\Exception $e) {
+            // continue on
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $strAddress
+     * @param BitcoinCashNetworkInterface $network
+     * @return CashAddress|null
+     */
+    protected function readBase32($strAddress, BitcoinCashNetworkInterface $network) {
+        try {
+            list ($prefix, $scriptType, $hash) = \CashAddr\CashAddress::decode($strAddress);
+            if ($prefix !== $network->getCashAddressPrefix()) {
+                return null;
+            }
+            return new CashAddress($scriptType, $hash);
+        } catch (\Exception $e) {
+            // continue on
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $strAddress
+     * @return AddressInterface
+     */
+    abstract public function fromString($strAddress);
+
+    /**
+     * @param ScriptInterface $script
+     * @return AddressInterface
+     */
+    abstract public function fromOutputScript(ScriptInterface $script);
+}

--- a/src/Address/AddressReaderBase.php
+++ b/src/Address/AddressReaderBase.php
@@ -75,10 +75,11 @@ abstract class AddressReaderBase
     }
 
     /**
-     * @param string $strAddress
-     * @return AddressInterface
+     * @param $strAddress
+     * @param NetworkInterface|null $network
+     * @return mixed
      */
-    abstract public function fromString($strAddress);
+    abstract public function fromString($strAddress, NetworkInterface $network = null);
 
     /**
      * @param ScriptInterface $script

--- a/src/Address/AddressReaderBase.php
+++ b/src/Address/AddressReaderBase.php
@@ -5,14 +5,9 @@ namespace Blocktrail\SDK\Address;
 use BitWasp\Bitcoin\Address\AddressInterface;
 use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
 use BitWasp\Bitcoin\Address\ScriptHashAddress;
-use BitWasp\Bitcoin\Address\SegwitAddress;
 use BitWasp\Bitcoin\Base58;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Script\ScriptInterface;
-use BitWasp\Bitcoin\Script\ScriptType;
-use BitWasp\Bitcoin\SegwitBech32;
-use BitWasp\Buffertools\Buffer;
-use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
 
 abstract class AddressReaderBase
 {
@@ -33,44 +28,6 @@ abstract class AddressReaderBase
             }
         } catch (\Exception $e) {
         }
-        return null;
-    }
-
-    /**
-     * @param string $strAddress
-     * @param NetworkInterface $network
-     * @return SegwitAddress|null
-     */
-    protected function readBech32($strAddress, NetworkInterface $network) {
-        try {
-            return new SegwitAddress(SegwitBech32::decode($strAddress, $network));
-        } catch (\Exception $e) {
-            // continue on
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string $strAddress
-     * @param BitcoinCashNetworkInterface $network
-     * @return CashAddress|null
-     */
-    protected function readBase32($strAddress, BitcoinCashNetworkInterface $network) {
-        try {
-            list ($prefix, $scriptType, $hash) = \CashAddr\CashAddress::decode($strAddress);
-            if ($prefix !== $network->getCashAddressPrefix()) {
-                return null;
-            }
-            if (!($scriptType === ScriptType::P2PKH || $scriptType === ScriptType::P2SH)) {
-                return null;
-            }
-
-            return new CashAddress($scriptType, new Buffer($hash, 20));
-        } catch (\Exception $e) {
-            // continue on
-        }
-
         return null;
     }
 

--- a/src/Address/AddressReaderBase.php
+++ b/src/Address/AddressReaderBase.php
@@ -9,7 +9,9 @@ use BitWasp\Bitcoin\Address\SegwitAddress;
 use BitWasp\Bitcoin\Base58;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\ScriptType;
 use BitWasp\Bitcoin\SegwitBech32;
+use BitWasp\Buffertools\Buffer;
 use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
 
 abstract class AddressReaderBase
@@ -31,7 +33,6 @@ abstract class AddressReaderBase
             }
         } catch (\Exception $e) {
         }
-
         return null;
     }
 
@@ -61,7 +62,11 @@ abstract class AddressReaderBase
             if ($prefix !== $network->getCashAddressPrefix()) {
                 return null;
             }
-            return new CashAddress($scriptType, $hash);
+            if (!($scriptType === ScriptType::P2PKH || $scriptType === ScriptType::P2SH)) {
+                return null;
+            }
+
+            return new CashAddress($scriptType, new Buffer($hash, 20));
         } catch (\Exception $e) {
             // continue on
         }

--- a/src/Address/AddressReaderBase.php
+++ b/src/Address/AddressReaderBase.php
@@ -34,7 +34,7 @@ abstract class AddressReaderBase
     /**
      * @param $strAddress
      * @param NetworkInterface|null $network
-     * @return mixed
+     * @return AddressInterface
      */
     abstract public function fromString($strAddress, NetworkInterface $network = null);
 

--- a/src/Address/Base32AddressInterface.php
+++ b/src/Address/Base32AddressInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Blocktrail\SDK\Address;
+
+use BitWasp\Bitcoin\Address\AddressInterface;
+use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
+
+interface Base32AddressInterface extends AddressInterface
+{
+    /**
+     * @param BitcoinCashNetworkInterface $network
+     * @return string
+     */
+    public function getPrefix(BitcoinCashNetworkInterface $network);
+}

--- a/src/Address/BitcoinAddressReader.php
+++ b/src/Address/BitcoinAddressReader.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Blocktrail\SDK\Address;
+
+use BitWasp\Bitcoin\Address\AddressInterface;
+use BitWasp\Bitcoin\Address\Base58AddressInterface;
+use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Address\SegwitAddress;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Script\WitnessProgram;
+use BitWasp\Buffertools\BufferInterface;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
+
+class BitcoinAddressReader extends AddressReaderBase
+{
+    /**
+     * @param ScriptInterface $outputScript
+     * @return AddressInterface|PayToPubKeyHashAddress|ScriptHashAddress|SegwitAddress
+     */
+    public function fromOutputScript(ScriptInterface $outputScript) {
+        $wp = null;
+        if ($outputScript->isWitness($wp)) {
+            /** @var WitnessProgram $wp */
+            return new SegwitAddress($wp);
+        }
+
+        $decode = (new OutputClassifier())->decode($outputScript);
+        switch ($decode->getType()) {
+            case ScriptType::P2PKH:
+                /** @var BufferInterface $solution */
+                return new PayToPubKeyHashAddress($decode->getSolution());
+            case ScriptType::P2SH:
+                /** @var BufferInterface $solution */
+                return new ScriptHashAddress($decode->getSolution());
+            default:
+                throw new \RuntimeException('Script type is not associated with an address');
+        }
+    }
+
+    /**
+     * @param string $strAddress
+     * @param NetworkInterface|null $network
+     * @return Base58AddressInterface|SegwitAddress|null
+     * @throws BlocktrailSDKException
+     */
+    public function fromString($strAddress, NetworkInterface $network = null) {
+        $network = $network ?: Bitcoin::getNetwork();
+
+        if (($base58Address = $this->readBase58($strAddress, $network))) {
+            return $base58Address;
+        }
+
+        if (($bech32Address = $this->readBech32($strAddress, $network))) {
+            return $bech32Address;
+        }
+
+        throw new BlocktrailSDKException("Address not recognized");
+    }
+}

--- a/src/Address/BitcoinAddressReader.php
+++ b/src/Address/BitcoinAddressReader.php
@@ -13,11 +13,28 @@ use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Script\ScriptType;
 use BitWasp\Bitcoin\Script\WitnessProgram;
+use BitWasp\Bitcoin\SegwitBech32;
 use BitWasp\Buffertools\BufferInterface;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 
 class BitcoinAddressReader extends AddressReaderBase
 {
+
+    /**
+     * @param string $strAddress
+     * @param NetworkInterface $network
+     * @return SegwitAddress|null
+     */
+    protected function readSegwitAddress($strAddress, NetworkInterface $network) {
+        try {
+            return new SegwitAddress(SegwitBech32::decode($strAddress, $network));
+        } catch (\Exception $e) {
+            // continue on
+        }
+
+        return null;
+    }
+
     /**
      * @param ScriptInterface $outputScript
      * @return AddressInterface|PayToPubKeyHashAddress|ScriptHashAddress|SegwitAddress
@@ -55,7 +72,7 @@ class BitcoinAddressReader extends AddressReaderBase
             return $base58Address;
         }
 
-        if (($bech32Address = $this->readBech32($strAddress, $network))) {
+        if (($bech32Address = $this->readSegwitAddress($strAddress, $network))) {
             return $bech32Address;
         }
 

--- a/src/Address/BitcoinCashAddressReader.php
+++ b/src/Address/BitcoinCashAddressReader.php
@@ -37,6 +37,7 @@ class BitcoinCashAddressReader extends AddressReaderBase
      */
     public function fromString($strAddress, NetworkInterface $network = null) {
         $network = $network ?: Bitcoin::getNetwork();
+
         if (($base58Address = $this->readBase58($strAddress, $network))) {
             return $base58Address;
         }

--- a/src/Address/BitcoinCashAddressReader.php
+++ b/src/Address/BitcoinCashAddressReader.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Blocktrail\SDK\Address;
+
+use BitWasp\Bitcoin\Address\Base58AddressInterface;
+use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Buffertools\BufferInterface;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
+use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
+
+class BitcoinCashAddressReader extends AddressReaderBase
+{
+    /**
+     * @var bool
+     */
+    private $useNewCashAddress;
+
+    /**
+     * BitcoinCashAddressReader constructor.
+     * @param bool $useNewCashAddress
+     */
+    public function __construct($useNewCashAddress) {
+        $this->useNewCashAddress = (bool) $useNewCashAddress;
+    }
+
+    /**
+     * @param string $strAddress
+     * @param NetworkInterface|null $network
+     * @return Base58AddressInterface|CashAddress
+     * @throws BlocktrailSDKException
+     */
+    public function fromString($strAddress, NetworkInterface $network = null) {
+        $network = $network ?: Bitcoin::getNetwork();
+        if (($base58Address = $this->readBase58($strAddress, $network))) {
+            return $base58Address;
+        }
+
+        if ($this->useNewCashAddress && $network instanceof BitcoinCashNetworkInterface) {
+            if (($base32Address = $this->readBase32($strAddress, $network))) {
+                return $base32Address;
+            }
+        }
+
+        throw new BlocktrailSDKException("Address not recognized");
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @return Base58AddressInterface|CashAddress
+     */
+    public function fromOutputScript(ScriptInterface $script) {
+        $decode = (new OutputClassifier())->decode($script);
+
+        switch ($decode->getType()) {
+            case ScriptType::P2PKH:
+                /** @var BufferInterface $solution */
+                if ($this->useNewCashAddress) {
+                    return new CashAddress(ScriptType::P2PKH, $decode->getSolution());
+                } else {
+                    return new PayToPubKeyHashAddress($decode->getSolution());
+                }
+                break;
+            case ScriptType::P2SH:
+                /** @var BufferInterface $solution */
+                if ($this->useNewCashAddress) {
+                    return new CashAddress(ScriptType::P2SH, $decode->getSolution());
+                } else {
+                    return new ScriptHashAddress($decode->getSolution());
+                }
+                break;
+            default:
+                throw new \RuntimeException('Script type is not associated with an address');
+        }
+    }
+}

--- a/src/Address/CashAddress.php
+++ b/src/Address/CashAddress.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Blocktrail\SDK\Address;
+
+use BitWasp\Bitcoin\Address\Address;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Buffertools\BufferInterface;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
+use Blocktrail\SDK\Network\BitcoinCashNetworkInterface;
+
+class CashAddress extends Address implements Base32AddressInterface
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var BufferInterface
+     */
+    protected $hash;
+
+    /**
+     * CashAddress constructor.
+     * @param string $type
+     * @param BufferInterface $hash
+     * @throws BlocktrailSDKException
+     */
+    public function __construct($type, BufferInterface $hash)
+    {
+        if ($type !== ScriptType::P2PKH && $type !== ScriptType::P2SH) {
+            throw new BlocktrailSDKException("Invalid type for bitcoin cash address");
+        }
+
+        $this->type = $type;
+
+        parent::__construct($hash);
+    }
+
+    /**
+     * @param BitcoinCashNetworkInterface $network
+     * @return string
+     */
+    public function getPrefix(BitcoinCashNetworkInterface $network)
+    {
+        return $network->getCashAddressPrefix();
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param NetworkInterface|null $network
+     * @return string
+     * @throws BlocktrailSDKException
+     * @throws \CashAddr\Exception\Base32Exception
+     * @throws \CashAddr\Exception\CashAddressException
+     */
+    public function getAddress(NetworkInterface $network = null)
+    {
+        if (!($network instanceof BitcoinCashNetworkInterface)) {
+            throw new BlocktrailSDKException("Wrong network passed - must implement BitcoinCashNetworkInterface");
+        }
+
+        return \CashAddr\CashAddress::encode(
+            $network->getCashAddressPrefix(),
+            $this->type,
+            $this->hash->getBinary()
+        );
+    }
+
+    /**
+     * @return \BitWasp\Bitcoin\Script\ScriptInterface
+     */
+    public function getScriptPubKey()
+    {
+        if ($this->type === ScriptType::P2PKH) {
+            return ScriptFactory::scriptPubKey()->p2pkh($this->hash);
+        } else {
+            return ScriptFactory::scriptPubKey()->p2sh($this->hash);
+        }
+    }
+}

--- a/src/Network/BitcoinCash.php
+++ b/src/Network/BitcoinCash.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Blocktrail\SDK\Network;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+
+class BitcoinCash extends Network implements BitcoinCashNetworkInterface
+{
+    /**
+     * @var string
+     */
+    private $cashAddressPrefix;
+
+    /**
+     * BitcoinCash constructor.
+     * @param bool $testnet
+     * @throws \Exception
+     */
+    public function __construct(bool $testnet = false)
+    {
+        if ($testnet) {
+            $base = NetworkFactory::bitcoinTestnet();
+            $cashAddressPrefix = "bchtest";
+        } else {
+            $base = NetworkFactory::bitcoin();
+            $cashAddressPrefix = "bitcoincash";
+        }
+
+        parent::__construct(
+            $base->getAddressByte(),
+            $base->getP2shByte(),
+            $base->getPrivByte(),
+            $base->isTestnet()
+        );
+
+        $this->setHDPrivByte($base->getHDPrivByte());
+        $this->setHDPubByte($base->getHDPubByte());
+        $this->setNetMagicBytes($base->getNetMagicBytes());
+        $this->cashAddressPrefix = $cashAddressPrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCashAddressPrefix()
+    {
+        return $this->cashAddressPrefix;
+    }
+}

--- a/src/Network/BitcoinCash.php
+++ b/src/Network/BitcoinCash.php
@@ -17,7 +17,7 @@ class BitcoinCash extends Network implements BitcoinCashNetworkInterface
      * @param bool $testnet
      * @throws \Exception
      */
-    public function __construct(bool $testnet = false) {
+    public function __construct($testnet = false) {
         if ($testnet) {
             $base = NetworkFactory::bitcoinTestnet();
             $cashAddressPrefix = "bchtest";

--- a/src/Network/BitcoinCash.php
+++ b/src/Network/BitcoinCash.php
@@ -17,8 +17,7 @@ class BitcoinCash extends Network implements BitcoinCashNetworkInterface
      * @param bool $testnet
      * @throws \Exception
      */
-    public function __construct(bool $testnet = false)
-    {
+    public function __construct(bool $testnet = false) {
         if ($testnet) {
             $base = NetworkFactory::bitcoinTestnet();
             $cashAddressPrefix = "bchtest";
@@ -43,8 +42,7 @@ class BitcoinCash extends Network implements BitcoinCashNetworkInterface
     /**
      * @return string
      */
-    public function getCashAddressPrefix()
-    {
+    public function getCashAddressPrefix() {
         return $this->cashAddressPrefix;
     }
 }

--- a/src/Network/BitcoinCashNetworkInterface.php
+++ b/src/Network/BitcoinCashNetworkInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Blocktrail\SDK\Network;
+
+interface BitcoinCashNetworkInterface
+{
+    /**
+     * @return string
+     */
+    public function getCashAddressPrefix();
+}

--- a/src/OutputsNormalizer.php
+++ b/src/OutputsNormalizer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Blocktrail\SDK;
+
+class OutputsNormalizer
+{
+    private function readArrayFormat() {
+    }
+
+    private function readKeyedFormat() {
+    }
+
+    public function normalize(array $outputs) {
+        if (empty($outputs)) {
+            return [];
+        }
+
+        $keys = array_keys($outputs);
+        if ($keys[count($keys) - 1]) {
+        }
+    }
+}

--- a/src/OutputsNormalizer.php
+++ b/src/OutputsNormalizer.php
@@ -2,21 +2,132 @@
 
 namespace Blocktrail\SDK;
 
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\Opcodes;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Buffertools\Buffer;
+use Blocktrail\SDK\Address\AddressReaderBase;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
+
 class OutputsNormalizer
 {
-    private function readArrayFormat() {
+    /**
+     * @var AddressReaderBase
+     */
+    private $reader;
+
+    /**
+     * OutputsNormalizer constructor.
+     * @param AddressReaderBase $reader
+     */
+    public function __construct(AddressReaderBase $reader)
+    {
+        $this->reader = $reader;
     }
 
-    private function readKeyedFormat() {
+    /**
+     * @param array $output
+     * @return array
+     * @throws BlocktrailSDKException
+     */
+    protected function readArrayFormat(array $output, Network $network) {
+        if (array_key_exists("scriptPubKey", $output) && array_key_exists("value", $output)) {
+            return [
+                "scriptPubKey" => $output['scriptPubKey'],
+                "value" => $output['value'],
+            ];
+        } else if (array_key_exists("address", $output) && array_key_exists("value", $output)) {
+            return $this->parseAddressOutput($output['address'], $output['value'], $network);
+        } else {
+            $keys = array_keys($output);
+            if (count($keys) === 2 && count($output) === 2 && $keys[0] === 0 && $keys[1] === 1) {
+                return $this->parseAddressOutput($output[0], $output[1], $network);
+            } else {
+                throw new BlocktrailSDKException("Invalid transaction output for numerically indexed list");
+            }
+        }
     }
 
-    public function normalize(array $outputs) {
+    /**
+     * @param $address
+     * @param $value
+     * @return array
+     */
+    private function parseAddressOutput($address, $value, $network) {
+        if ($address === "opreturn") {
+            $data = new Buffer($value);
+            $scriptPubKey = ScriptFactory::sequence([Opcodes::OP_RETURN, $data]);
+            return [
+                "value" => 0,
+                "scriptPubKey" => $scriptPubKey,
+            ];
+        }
+
+        $object = $this->reader->fromString($address, $network);
+        return [
+            "value" => $value,
+            "scriptPubKey" => $object->getScriptPubKey(),
+        ];
+    }
+
+    /**
+     * @param array $outputs
+     * @param NetworkInterface|null $network
+     * @return array
+     * @throws BlocktrailSDKException
+     */
+    public function normalize(array $outputs, NetworkInterface $network = null) {
+        $network = $network ?: Bitcoin::getNetwork();
         if (empty($outputs)) {
             return [];
         }
 
         $keys = array_keys($outputs);
-        if ($keys[count($keys) - 1]) {
+        $newOutputs = [];
+        if (is_int($keys[0])) {
+            foreach ($outputs as $i => $output) {
+                if (!is_int($i)) {
+                    throw new BlocktrailSDKException("Encountered invalid index while traversing numerically indexed list");
+                }
+                if (!is_array($output)) {
+                    throw new BlocktrailSDKException("Encountered invalid output while traversing numerically indexed list");
+                }
+                $newOutputs[] = $this->readArrayFormat($output, $network);
+            }
+        } else if (is_string($keys[0])) {
+            foreach ($outputs as $address => $value) {
+                if (!is_string($address)) {
+                    throw new BlocktrailSDKException("Encountered invalid address while traversing address keyed list..");
+                }
+
+                $newOutputs[] = $this->parseAddressOutput($address, $value, $network);
+            }
         }
+
+        foreach ($newOutputs as &$newOutput) {
+            if (fmod($newOutput['value'], 1)) {
+                throw new BlocktrailSDKException("Value should be in Satoshis");
+            }
+
+            if (is_string($newOutput['scriptPubKey'])) {
+                $newOutput['scriptPubKey'] = ScriptFactory::fromHex($newOutput['scriptPubKey']);
+            }
+
+            if (strlen($newOutput['scriptPubKey']->getBinary()) < 1) {
+                throw new BlocktrailSDKException("Script cannot be empty");
+            }
+
+            if ($newOutput['scriptPubKey']->getBinary()[0] !== "\x6a") {
+                if (!$newOutput['value']) {
+                    throw new BlocktrailSDKException("Values should be non zero");
+                } else if ($newOutput['value'] < Blocktrail::DUST) {
+                    throw new BlocktrailSDKException("Values should be more than dust (" . Blocktrail::DUST . ")");
+                }
+            }
+        }
+
+        return $newOutputs;
     }
 }

--- a/src/OutputsNormalizer.php
+++ b/src/OutputsNormalizer.php
@@ -22,8 +22,7 @@ class OutputsNormalizer
      * OutputsNormalizer constructor.
      * @param AddressReaderBase $reader
      */
-    public function __construct(AddressReaderBase $reader)
-    {
+    public function __construct(AddressReaderBase $reader) {
         $this->reader = $reader;
     }
 

--- a/src/SizeEstimation.php
+++ b/src/SizeEstimation.php
@@ -260,7 +260,7 @@ class SizeEstimation
     public static function estimateOutputsSize(array $outputs) {
         $outputSize = 0;
         foreach ($outputs as $output) {
-            $outputSize += 8;
+            $size = 8;
 
             $scriptSize = null;
             if ($output instanceof TransactionOutputInterface) {
@@ -273,13 +273,13 @@ class SizeEstimation
                         $scriptSize = strlen($output['scriptPubKey']) / 2;
                     }
                 } else {
-                    $scriptSize += 25;
+                    $scriptSize = 25;
                 }
             }
 
-            $outputSize += SizeEstimation::getLengthOfVarInt($scriptSize) + $scriptSize;
+            $size += SizeEstimation::getLengthOfVarInt($scriptSize) + $scriptSize;
+            $outputSize += $size;
         }
-
         return $outputSize;
     }
 

--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -43,11 +43,17 @@ class TransactionBuilder {
     private $addressReader;
 
     /**
+     * @var OutputsNormalizer
+     */
+    private $outputNormalizer;
+
+    /**
      * TransactionBuilder constructor.
      * @param AddressReaderBase $addressReader
      */
     public function __construct(AddressReaderBase $addressReader) {
         $this->addressReader = $addressReader;
+        $this->outputNormalizer = new OutputsNormalizer($this->addressReader);
     }
 
     /**
@@ -134,6 +140,8 @@ class TransactionBuilder {
      * @return $this
      */
     public function addOutput($output) {
+        $output = $this->outputNormalizer->normalize([$output])[0];
+
         $this->outputs[] = $output;
 
         return $this;

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -677,6 +677,9 @@ abstract class Wallet implements WalletInterface {
         return $result;
     }
 
+    private static function convertPayToOutputs() {
+    }
+
     /**
      * 'fund' the txBuilder with UTXOs (modified in place)
      *
@@ -687,6 +690,7 @@ abstract class Wallet implements WalletInterface {
      * @return TransactionBuilder
      */
     public function coinSelectionForTxBuilder(TransactionBuilder $txBuilder, $lockUTXOs = true, $allowZeroConf = false, $forceFee = null) {
+
         // get the data we should use for this transaction
         $coinSelection = $this->coinSelection($txBuilder->getOutputs(/* $json = */true), $lockUTXOs, $allowZeroConf, $txBuilder->getFeeStrategy(), $forceFee);
         
@@ -1128,6 +1132,8 @@ abstract class Wallet implements WalletInterface {
      * @return array
      */
     public function coinSelection($outputs, $lockUTXO = true, $allowZeroConf = false, $feeStrategy = self::FEE_STRATEGY_OPTIMAL, $forceFee = null) {
+
+
         $result = $this->sdk->coinSelection($this->identifier, $outputs, $lockUTXO, $allowZeroConf, $feeStrategy, $forceFee);
 
         $this->highPriorityFeePerKB = $result['fees'][self::FEE_STRATEGY_HIGH_PRIORITY];

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -2,13 +2,16 @@
 
 namespace Blocktrail\SDK;
 
-use BitWasp\Bitcoin\Address\AddressFactory;
+use BitWasp\Bitcoin\Address\Base58AddressInterface;
+use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\MessageSigner\MessageSigner;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\ScriptType;
 use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Transaction\Factory\SignData;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
@@ -18,6 +21,9 @@ use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
 use BitWasp\Bitcoin\Transaction\Transaction;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
 use BitWasp\Buffertools\Buffer;
+use Blocktrail\SDK\Address\AddressReaderBase;
+use Blocktrail\SDK\Address\BitcoinCashAddressReader;
+use Blocktrail\SDK\Address\CashAddress;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Bitcoin\BIP32Path;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
@@ -124,6 +130,9 @@ abstract class Wallet implements WalletInterface {
      */
     protected $derivationsByAddress = [];
 
+    /**
+     * @var string
+     */
     protected $checksum;
 
     /**
@@ -146,6 +155,11 @@ abstract class Wallet implements WalletInterface {
      */
     protected $changeIndex;
 
+    /**
+     * @var AddressReaderBase
+     */
+    protected $addressReader;
+
     protected $highPriorityFeePerKB;
     protected $optimalFeePerKB;
     protected $lowPriorityFeePerKB;
@@ -165,7 +179,7 @@ abstract class Wallet implements WalletInterface {
      * @param string                        $checksum
      * @throws BlocktrailSDKException
      */
-    public function __construct(BlocktrailSDKInterface $sdk, $identifier, array $primaryPublicKeys, $backupPublicKey, array $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum) {
+    public function __construct(BlocktrailSDKInterface $sdk, $identifier, array $primaryPublicKeys, $backupPublicKey, array $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, AddressReaderBase $addressReader, $checksum) {
         $this->sdk = $sdk;
 
         $this->identifier = $identifier;
@@ -194,9 +208,17 @@ abstract class Wallet implements WalletInterface {
             $changeIdx = self::CHAIN_BCC_DEFAULT;
         }
 
+        $this->addressReader = $addressReader;
         $this->isSegwit = (bool) $segwit;
         $this->chainIndex = $chainIdx;
         $this->changeIndex = $changeIdx;
+    }
+
+    /**
+     * @return AddressReaderBase
+     */
+    public function getAddressReader() {
+        return $this->addressReader;
     }
 
     /**
@@ -311,12 +333,37 @@ abstract class Wallet implements WalletInterface {
 
             $path = $new['path'];
             $address = $new['address'];
+
+            $serverDecoded = $this->addressReader->fromString($address);
+
             $redeemScript = $new['redeem_script'];
             $witnessScript = array_key_exists('witness_script', $new) ? $new['witness_script'] : null;
 
             /** @var ScriptInterface $checkRedeemScript */
             /** @var ScriptInterface $checkWitnessScript */
             list($checkAddress, $checkRedeemScript, $checkWitnessScript) = $this->getRedeemScriptByPath($path);
+
+            $oursDecoded = $this->addressReader->fromString($checkAddress);
+
+            if ($this->network === "bitcoincash" &&
+                $serverDecoded instanceof Base58AddressInterface &&
+                $oursDecoded instanceof CashAddress
+            ) {
+                // our address is a cashaddr, server gave us base58.
+
+                if (!$oursDecoded->getHash()->equals($serverDecoded->getHash())) {
+                    throw new BlocktrailSDKException("Failed to verify legacy address from server [hash mismatch]");
+                }
+
+                $matchedP2PKH = $serverDecoded instanceof PayToPubKeyHashAddress && $oursDecoded->getType() === ScriptType::P2PKH;
+                $matchedP2SH = $serverDecoded instanceof ScriptHashAddress && $oursDecoded->getType() === ScriptType::P2SH;
+                if (!($matchedP2PKH || $matchedP2SH)) {
+                    throw new BlocktrailSDKException("Failed to verify legacy address from server [prefix mismatch]");
+                }
+
+                // promote the legacy address to our cashaddr, as they are equivalent.
+                $address = $checkAddress;
+            }
 
             if ($checkAddress != $address) {
                 throw new \Exception("Failed to verify that address from API [{$address}] matches address locally [{$checkAddress}]");
@@ -449,7 +496,9 @@ abstract class Wallet implements WalletInterface {
             throw new BlocktrailSDKException("Unsupported chain in path");
         }
 
-        return new WalletScript($path, $scriptPubKey, $redeemScript, $witnessScript);
+        $address = $this->addressReader->fromOutputScript($scriptPubKey);
+
+        return new WalletScript($path, $scriptPubKey, $redeemScript, $witnessScript, $address);
     }
 
     /**
@@ -459,6 +508,11 @@ abstract class Wallet implements WalletInterface {
      * @return array
      */
     public function getPathForAddress($address) {
+        $decoded = $this->addressReader->fromString($address);
+        if ($decoded instanceof CashAddress) {
+            $address = $decoded->getLegacyAddress();
+        }
+
         return $this->sdk->getPathForAddress($this->identifier, $address);
     }
 
@@ -558,7 +612,7 @@ abstract class Wallet implements WalletInterface {
 
         $outputs = self::normalizeOutputsStruct($outputs);
 
-        $txBuilder = new TransactionBuilder();
+        $txBuilder = new TransactionBuilder($this->addressReader);
         $txBuilder->randomizeChangeOutput($randomizeChangeIdx);
         $txBuilder->setFeeStrategy($feeStrategy);
         $txBuilder->setChangeAddress($changeAddress);
@@ -686,7 +740,7 @@ abstract class Wallet implements WalletInterface {
                 $output = $tx['outputs'][$utxo->index];
 
                 if (!$utxo->address) {
-                    $utxo->address = AddressFactory::fromString($output['address']);
+                    $utxo->address = $this->addressReader->fromString($output['address']);
                 }
                 if (!$utxo->value) {
                     $utxo->value = $output['value'];
@@ -749,7 +803,7 @@ abstract class Wallet implements WalletInterface {
             if (isset($out['scriptPubKey'])) {
                 $txb->output($out['value'], $out['scriptPubKey']);
             } elseif (isset($out['address'])) {
-                $txb->payToAddress($out['value'], AddressFactory::fromString($out['address']));
+                $txb->output($out['value'], $this->addressReader->fromString($out['address'])->getScriptPubKey());
             } else {
                 throw new \Exception();
             }

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -1129,7 +1129,15 @@ abstract class Wallet implements WalletInterface {
      * @return array
      */
     public function coinSelection($outputs, $lockUTXO = true, $allowZeroConf = false, $feeStrategy = self::FEE_STRATEGY_OPTIMAL, $forceFee = null) {
-        $result = $this->sdk->coinSelection($this->identifier, $outputs, $lockUTXO, $allowZeroConf, $feeStrategy, $forceFee);
+        $send = [];
+        foreach ((new OutputsNormalizer($this->addressReader))->normalize($outputs) as $output) {
+            $send[] = [
+                "value" => $output['value'],
+                "scriptPubKey" => $output['scriptPubKey']->getHex(),
+            ];
+        }
+
+        $result = $this->sdk->coinSelection($this->identifier, $send, $lockUTXO, $allowZeroConf, $feeStrategy, $forceFee);
 
         $this->highPriorityFeePerKB = $result['fees'][self::FEE_STRATEGY_HIGH_PRIORITY];
         $this->optimalFeePerKB = $result['fees'][self::FEE_STRATEGY_OPTIMAL];

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -610,7 +610,7 @@ abstract class Wallet implements WalletInterface {
             throw new \InvalidArgumentException("feeStrategy should be set to force_fee to set a forced fee");
         }
 
-        $outputs = self::normalizeOutputsStruct($outputs);
+        $outputs = (new OutputsNormalizer($this->getAddressReader()))->normalize($outputs);
 
         $txBuilder = new TransactionBuilder($this->addressReader);
         $txBuilder->randomizeChangeOutput($randomizeChangeIdx);
@@ -618,7 +618,7 @@ abstract class Wallet implements WalletInterface {
         $txBuilder->setChangeAddress($changeAddress);
 
         foreach ($outputs as $output) {
-            $txBuilder->addRecipient($output['address'], $output['value']);
+            $txBuilder->addOutput($output);
         }
 
         $this->coinSelectionForTxBuilder($txBuilder, true, $allowZeroConf, $forceFee);
@@ -675,9 +675,6 @@ abstract class Wallet implements WalletInterface {
         }
 
         return $result;
-    }
-
-    private static function convertPayToOutputs() {
     }
 
     /**
@@ -1132,8 +1129,6 @@ abstract class Wallet implements WalletInterface {
      * @return array
      */
     public function coinSelection($outputs, $lockUTXO = true, $allowZeroConf = false, $feeStrategy = self::FEE_STRATEGY_OPTIMAL, $forceFee = null) {
-
-
         $result = $this->sdk->coinSelection($this->identifier, $outputs, $lockUTXO, $allowZeroConf, $feeStrategy, $forceFee);
 
         $this->highPriorityFeePerKB = $result['fees'][self::FEE_STRATEGY_HIGH_PRIORITY];

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -814,7 +814,7 @@ abstract class Wallet implements WalletInterface {
     }
 
     public function determineFeeAndChange(TransactionBuilder $txBuilder, $highPriorityFeePerKB, $optimalFeePerKB, $lowPriorityFeePerKB) {
-        $send = $txBuilder->getOutputs();
+        $send = (new OutputsNormalizer($this->addressReader))->normalize($txBuilder->getOutputs());
         $utxos = $txBuilder->getUtxos();
 
         $fee = $txBuilder->getFee();

--- a/src/WalletInterface.php
+++ b/src/WalletInterface.php
@@ -32,6 +32,11 @@ interface WalletInterface {
     public function getBackupKey();
 
     /**
+     * @return mixed
+     */
+    public function getAddressReader();
+
+    /**
      * return list of Blocktrail co-sign extended public keys
      *
      * @return array[]      [ [xpub, path] ]

--- a/src/WalletInterface.php
+++ b/src/WalletInterface.php
@@ -2,6 +2,7 @@
 
 namespace Blocktrail\SDK;
 
+use Blocktrail\SDK\Address\AddressReaderBase;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Bitcoin\BIP32Path;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
@@ -32,7 +33,7 @@ interface WalletInterface {
     public function getBackupKey();
 
     /**
-     * @return mixed
+     * @return AddressReaderBase
      */
     public function getAddressReader();
 

--- a/src/WalletV1.php
+++ b/src/WalletV1.php
@@ -5,7 +5,9 @@ namespace Blocktrail\SDK;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39SeedGenerator;
+use Blocktrail\SDK\Address\AddressReaderBase;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Exceptions\NotImplementedException;
 
 class WalletV1 extends Wallet {
@@ -27,12 +29,15 @@ class WalletV1 extends Wallet {
      * @param int                           $keyIndex
      * @param string                        $network
      * @param bool                          $testnet
+     * @param bool                          $segwit
+     * @param AddressReaderBase             $addressReader
      * @param string                        $checksum
+     * @throws                              BlocktrailSDKException
      */
-    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $primaryMnemonic, array $primaryPublicKeys, $backupPublicKey, array $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum) {
+    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $primaryMnemonic, array $primaryPublicKeys, $backupPublicKey, array $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, AddressReaderBase $addressReader, $checksum) {
         $this->primaryMnemonic = $primaryMnemonic;
 
-        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum);
+        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $addressReader, $checksum);
     }
 
     /**

--- a/src/WalletV2.php
+++ b/src/WalletV2.php
@@ -7,6 +7,7 @@ use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Mnemonic\MnemonicFactory;
 use BitWasp\Buffertools\Buffer;
 use Blocktrail\CryptoJSAES\CryptoJSAES;
+use Blocktrail\SDK\Address\AddressReaderBase;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Exceptions\WalletDecryptException;
@@ -34,12 +35,14 @@ class WalletV2 extends Wallet {
      * @param bool                   $testnet
      * @param bool                   $segwit
      * @param string                 $checksum
+     * @param AddressReaderBase      $addressReader
+     * @throws                       BlocktrailSDKException
      */
-    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $encryptedPrimarySeed, $encryptedSecret, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum) {
+    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $encryptedPrimarySeed, $encryptedSecret, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, AddressReaderBase $addressReader, $checksum) {
         $this->encryptedPrimarySeed = $encryptedPrimarySeed;
         $this->encryptedSecret = $encryptedSecret;
 
-        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum);
+        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $addressReader, $checksum);
     }
 
     /**

--- a/src/WalletV3.php
+++ b/src/WalletV3.php
@@ -5,6 +5,7 @@ namespace Blocktrail\SDK;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
+use Blocktrail\SDK\Address\AddressReaderBase;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
 use Blocktrail\SDK\Exceptions\WalletDecryptException;
@@ -45,9 +46,12 @@ class WalletV3 extends Wallet
      * @param int                    $keyIndex
      * @param string                 $network
      * @param bool                   $testnet
+     * @param bool                   $segwit
+     * @param AddressReaderBase      $addressReader
      * @param string                 $checksum
+     * @throws                       BlocktrailSDKException
      */
-    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $encryptedPrimarySeed, $encryptedSecret, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum) {
+    public function __construct(BlocktrailSDKInterface $sdk, $identifier, $encryptedPrimarySeed, $encryptedSecret, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, AddressReaderBase $addressReader, $checksum) {
         if ($encryptedPrimarySeed !== null && !($encryptedPrimarySeed instanceof Buffer)) {
             throw new \InvalidArgumentException('Encrypted Primary Seed must be a Buffer or null');
         }
@@ -57,7 +61,7 @@ class WalletV3 extends Wallet
         $this->encryptedPrimarySeed = $encryptedPrimarySeed;
         $this->encryptedSecret = $encryptedSecret;
 
-        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $checksum);
+        parent::__construct($sdk, $identifier, $primaryPublicKeys, $backupPublicKey, $blocktrailPublicKeys, $keyIndex, $network, $testnet, $segwit, $addressReader, $checksum);
     }
 
     /**

--- a/tests/BitcoinCashAddressTest.php
+++ b/tests/BitcoinCashAddressTest.php
@@ -66,22 +66,25 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
         $this->assertInstanceOf(CashAddress::class, $reader->fromString($newAddress, $tbcc));
     }
 
-//    public function testCanCoinSelectNewAddresses()
-//    {
-//        $isTestnet = true;
-//        $tbcc = new BitcoinCash($isTestnet);
-//
-//        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
-//        $cashAddrWallet = $client->initWallet([
-//            "identifier" => "unittest-transaction",
-//            "password" => "password",
-//            "use_cashaddress" => true,
-//        ]);
-//
-//        $selection = $cashAddrWallet->coinSelection([
-//            "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu" => 1234123,
-//        ], false);
-//
-//        var_Dump($selection);
-//    }
+    public function testCanCoinSelectNewCashAddresses()
+    {
+        $isTestnet = true;
+        $network = new BitcoinCash($isTestnet);
+        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
+        $cashAddrWallet = $client->initWallet([
+            "identifier" => "unittest-transaction",
+            "password" => "password",
+            "use_cashaddress" => true,
+        ]);
+
+        $str = "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu";
+        $cashaddr = $cashAddrWallet->getAddressReader()->fromString($str, $network);
+
+        $selection = $cashAddrWallet->coinSelection([
+             $cashaddr->getAddress($network) => 1234123,
+        ], false);
+
+        $this->assertArrayHasKey('utxos', $selection);
+        $this->assertTrue(count($selection['utxos']) > 0);
+    }
 }

--- a/tests/BitcoinCashAddressTest.php
+++ b/tests/BitcoinCashAddressTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Blocktrail\SDK\Tests;
+
+
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use Blocktrail\SDK\Address\BitcoinCashAddressReader;
+use Blocktrail\SDK\Address\CashAddress;
+use Blocktrail\SDK\Network\BitcoinCash;
+
+class BitcoinCashAddressTest extends BlocktrailTestCase
+{
+    public function testInitializeWithDefaultFormat() {
+        $isTestnet = true;
+        $tbcc = new BitcoinCash($isTestnet);
+        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
+        $legacyAddressWallet = $client->initWallet([
+            "identifier" => "unittest-transaction",
+            "password" => "password"
+        ]);
+
+        $this->assertInstanceOf(BitcoinCashAddressReader::class, $legacyAddressWallet->getAddressReader());
+        $this->assertInstanceOf(ScriptHashAddress::class, $legacyAddressWallet->getAddressReader()->fromString("2MsM9zVVyar93CWorEfH6PPW8QQmW3s1uh6", $tbcc));
+
+        $newAddressWallet = $client->initWallet([
+            "identifier" => "unittest-transaction",
+            "password" => "password",
+            "use_cashaddress" => true,
+        ]);
+
+        $this->assertInstanceOf(BitcoinCashAddressReader::class, $newAddressWallet->getAddressReader());
+        $this->assertInstanceOf(CashAddress::class, $newAddressWallet->getAddressReader()->fromString("bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu", $tbcc));
+    }
+
+    public function testCurrentDefaultIsOldFormat() {
+        $isTestnet = true;
+        $tbcc = new BitcoinCash($isTestnet);
+
+        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
+        $cashAddrWallet = $client->initWallet([
+            "identifier" => "unittest-transaction",
+            "password" => "password",
+            "use_cashaddress" => false,
+        ]);
+
+        $newAddress = $cashAddrWallet->getNewAddress();
+
+        $reader = $cashAddrWallet->getAddressReader();
+        $this->assertInstanceOf(ScriptHashAddress::class, $reader->fromString($newAddress, $tbcc));
+    }
+
+    public function testCanOptIntoNewAddressFormat() {
+        $isTestnet = true;
+        $tbcc = new BitcoinCash($isTestnet);
+
+        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
+        $cashAddrWallet = $client->initWallet([
+            "identifier" => "unittest-transaction",
+            "password" => "password",
+            "use_cashaddress" => true,
+        ]);
+
+        $newAddress = $cashAddrWallet->getNewAddress();
+
+        $reader = $cashAddrWallet->getAddressReader();
+        $this->assertInstanceOf(CashAddress::class, $reader->fromString($newAddress, $tbcc));
+    }
+
+//    public function testCanCoinSelectNewAddresses()
+//    {
+//        $isTestnet = true;
+//        $tbcc = new BitcoinCash($isTestnet);
+//
+//        $client = $this->setupBlocktrailSDK("BCC", $isTestnet);
+//        $cashAddrWallet = $client->initWallet([
+//            "identifier" => "unittest-transaction",
+//            "password" => "password",
+//            "use_cashaddress" => true,
+//        ]);
+//
+//        $selection = $cashAddrWallet->coinSelection([
+//            "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu" => 1234123,
+//        ], false);
+//
+//        var_Dump($selection);
+//    }
+}

--- a/tests/BitcoinCashAddressTest.php
+++ b/tests/BitcoinCashAddressTest.php
@@ -19,9 +19,11 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
             "password" => "password"
         ]);
 
+        $legacyAddress = "2N44ThNe8NXHyv4bsX8AoVCXquBRW94Ls7W";
         $this->assertInstanceOf(BitcoinCashAddressReader::class, $legacyAddressWallet->getAddressReader());
-        $this->assertInstanceOf(ScriptHashAddress::class, $legacyAddressWallet->getAddressReader()->fromString("2MsM9zVVyar93CWorEfH6PPW8QQmW3s1uh6", $tbcc));
+        $this->assertInstanceOf(ScriptHashAddress::class, $legacyAddressWallet->getAddressReader()->fromString($legacyAddress, $tbcc));
 
+        $cashAddress = "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu";
         $newAddressWallet = $client->initWallet([
             "identifier" => "unittest-transaction",
             "password" => "password",
@@ -29,7 +31,11 @@ class BitcoinCashAddressTest extends BlocktrailTestCase
         ]);
 
         $this->assertInstanceOf(BitcoinCashAddressReader::class, $newAddressWallet->getAddressReader());
-        $this->assertInstanceOf(CashAddress::class, $newAddressWallet->getAddressReader()->fromString("bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu", $tbcc));
+        $this->assertInstanceOf(CashAddress::class, $newAddressWallet->getAddressReader()->fromString($cashAddress, $tbcc));
+
+        $convertedLegacy = $client->getLegacyBitcoinCashAddress($cashAddress);
+
+        $this->assertEquals($legacyAddress, $convertedLegacy);
     }
 
     public function testCurrentDefaultIsOldFormat() {

--- a/tests/Network/BitcoinCashTest.php
+++ b/tests/Network/BitcoinCashTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Blocktrail\SDK\Tests\Network;
+
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Buffertools\Buffer;
+use Blocktrail\SDK\Address\CashAddress;
+use Blocktrail\SDK\Network\BitcoinCash;
+
+class BitcoinCashTest extends \PHPUnit_Framework_TestCase
+{
+    public function testnetProvider()
+    {
+        return [
+            [true, "bchtest",],
+            [false, "bitcoincash",],
+        ];
+    }
+
+    /**
+     * @param bool $testnet
+     * @dataProvider testnetProvider
+     */
+    public function testBitcoinCash($testnet, $cashAddrPrefix)
+    {
+        $network = new BitcoinCash($testnet);
+        $this->assertEquals($testnet, $network->isTestnet());
+        $this->assertEquals($cashAddrPrefix, $network->getCashAddressPrefix());
+
+        if ($testnet) {
+            $cmp = NetworkFactory::bitcoinTestnet();
+        } else {
+            $cmp = NetworkFactory::bitcoin();
+        }
+
+        $this->assertEquals($cmp->getAddressByte(), $network->getAddressByte());
+        $this->assertEquals($cmp->getP2shByte(), $network->getP2shByte());
+        $this->assertEquals($cmp->getPrivByte(), $network->getPrivByte());
+        $this->assertEquals($cmp->isTestnet(), $network->isTestnet());
+        $this->assertEquals($cmp->getNetMagicBytes(), $network->getNetMagicBytes());
+        $this->assertEquals($cmp->getHDPrivByte(), $network->getHDPrivByte());
+        $this->assertEquals($cmp->getHDPubByte(), $network->getHDPubByte());
+    }
+
+    /**
+     * @param $testnet
+     * @throws \Exception
+     * @dataProvider testnetProvider
+     * @expectedException \Exception
+     * @expectedExceptionMessage No bech32 prefix for segwit addresses set
+     */
+    public function testNoBech32($testnet)
+    {
+        $network = new BitcoinCash($testnet);
+        $network->getSegwitBech32Prefix();
+    }
+
+    public function getCashAddressFixture()
+    {
+        return [
+            [false, "scripthash", "76a04053bda0a88bda5177b86a15c3b29f559873", "bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq"],
+            [true, "scripthash", "76a04053bda0a88bda5177b86a15c3b29f559873", "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu"],
+            [false, "pubkeyhash", "011f28e473c95f4013d7d53ec5fbc3b42df8ed10", "bitcoincash:qqq3728yw0y47sqn6l2na30mcw6zm78dzqre909m2r"],
+        ];
+    }
+
+    /**
+     * @param $testnet
+     * @param $type
+     * @param $hashHex
+     * @param $expected
+     * @throws \Blocktrail\SDK\Exceptions\BlocktrailSDKException
+     * @throws \CashAddr\Exception\Base32Exception
+     * @throws \CashAddr\Exception\CashAddressException
+     * @throws \Exception
+     * @dataProvider getCashAddressFixture
+     */
+    public function testCashAddress($testnet, $type, $hashHex, $expected)
+    {
+        $network = new BitcoinCash($testnet);
+        $hash = Buffer::hex($hashHex);
+        $addr = new CashAddress($type, $hash);
+        $this->assertEquals($type, $addr->getType());
+        $this->assertTrue($hash->equals($addr->getHash()));
+        $this->assertEquals($network->getCashAddressPrefix(), $addr->getPrefix($network));
+        $this->assertEquals($expected, $addr->getAddress($network));
+    }
+}

--- a/tests/OutputsNormalizerTest.php
+++ b/tests/OutputsNormalizerTest.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Blocktrail\SDK\Tests;
+
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use Blocktrail\SDK\Address\BitcoinAddressReader;
+use Blocktrail\SDK\Address\BitcoinCashAddressReader;
+use Blocktrail\SDK\Blocktrail;
+use Blocktrail\SDK\Exceptions\BlocktrailSDKException;
+use Blocktrail\SDK\Network\BitcoinCash;
+use Blocktrail\SDK\OutputsNormalizer;
+
+class OutputsNormalizerTest extends BlocktrailTestCase
+{
+    private function loadAddressReader($network, $testnet) {
+        switch ($network) {
+            case "BTC":
+                if ($testnet) {
+                    return [NetworkFactory::bitcoinTestnet(), new BitcoinAddressReader()];
+                }
+                return [NetworkFactory::bitcoin(), new BitcoinAddressReader()];
+                break;
+            case "BCC":
+                return [new BitcoinCash($testnet), new BitcoinCashAddressReader(true)];
+                break;
+            default:
+                throw new \RuntimeException("Unknown network");
+        }
+    }
+
+    public function getFixtures() {
+        return [
+            [
+                "BTC",
+                true,
+                [
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => 12345,
+                    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7" => 99999,
+                ],
+                [
+                    [
+                        "scriptPubKey" => "00149bce9399f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ],
+                    [
+                        "scriptPubKey" => "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                        "value" => 99999,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [],
+                []
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    ["tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs", 12345]
+                ],
+                [
+                    [
+                        "scriptPubKey" => "00149bce9399f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "address" => "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs",
+                        "value" => 12345
+                    ]
+                ],
+                [
+                    [
+                        "scriptPubKey" => "00149bce9399f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "scriptPubKey" => "00149bce9399f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ],
+                    [
+                        "scriptPubKey" => "001442424242f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ]
+                ],
+                [
+                    [
+                        "scriptPubKey" => "00149bce9399f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ],
+                    [
+                        "scriptPubKey" => "001442424242f9eeddad66635d4be171ec8f14decc59",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7" => 12345
+                ],
+                [
+                    [
+                        "scriptPubKey" => "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "muinVykhtZyonxQxk8zBptX6Lmri91bdNG" => 12345
+                ],
+                [
+                    [
+                        "scriptPubKey" => "76a9149bce9399f9eeddad66635d4be171ec8f14decc5988ac",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "2N7T4CD6CEuNHJoGKpoJH3YexqektXjyy6L" => 12345
+                ],
+                [
+                    [
+                        "scriptPubKey" => "a9149bce9399f9eeddad66635d4be171ec8f14decc5987",
+                        "value" => 12345,
+                    ],
+                ]
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "address" => "opreturn",
+                        "value" => "to the moon!",
+                    ],
+                ],
+                [
+                    [
+                        "scriptPubKey" => "6a0c746f20746865206d6f6f6e21",
+                        "value" => 0,
+                    ]
+                ]
+            ],
+            [
+                "BCC",
+                true,
+                [
+                    "muinVykhtZyonxQxk8zBptX6Lmri91bdNG" => 12345
+                ],
+                [
+                    [
+                        "scriptPubKey" => "76a9149bce9399f9eeddad66635d4be171ec8f14decc5988ac",
+                        "value" => 12345,
+                    ]
+                ]
+            ],
+            [
+                "BCC",
+                false,
+                [
+                    "bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq" => 12345
+                ],
+                [
+                    [
+                        "scriptPubKey" => "a91476a04053bda0a88bda5177b86a15c3b29f55987387",
+                        "value" => 12345,
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param $network
+     * @param $testnet
+     * @param array $input
+     * @param array $expected
+     * @throws \Blocktrail\SDK\Exceptions\BlocktrailSDKException
+     * @dataProvider getFixtures
+     */
+    public function testOutputsNormalizer($network, $testnet, array $input, array $expected)
+    {
+        list ($network, $addressReader) = $this->loadAddressReader($network, $testnet);
+
+        $normalizer = new OutputsNormalizer($addressReader);
+        $outputs = $normalizer->normalize($input, $network);
+
+        $this->assertEquals(count($expected), count($outputs));
+        foreach ($expected as $i => $output) {
+            $result = $outputs[$i];
+            $this->assertEquals($output['value'], $result['value']);
+            $this->assertEquals($output['scriptPubKey'], $result['scriptPubKey']->getHex());
+        }
+    }
+
+    public function getErrorFixtures()
+    {
+        return [
+            [
+                "BTC",
+                true,
+                [
+                    []
+                ],
+                BlocktrailSDKException::class,
+                "Invalid transaction output for numerically indexed list",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => 12345,
+                    999999999 => 12390,
+                ],
+                BlocktrailSDKException::class,
+                "Encountered invalid address while traversing address keyed list",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    999999999 => 12390,
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => 12345,
+                ],
+                BlocktrailSDKException::class,
+                "Encountered invalid output while traversing numerically indexed list",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "address" => "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs",
+                        "value" => 1234,
+                    ],
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => 1,
+                ],
+                BlocktrailSDKException::class,
+                "Encountered invalid index while traversing numerically indexed list",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => 1234.1
+                ],
+                BlocktrailSDKException::class,
+                "Value should be in Satoshis",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs" => '1234.1'
+                ],
+                BlocktrailSDKException::class,
+                "Value should be in Satoshis",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "scriptPubKey" => "",
+                        "value" => 1234,
+                    ]
+                ],
+                BlocktrailSDKException::class,
+                "Script cannot be empty",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "address" => "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs",
+                        "value" => 0,
+                    ]
+                ],
+                BlocktrailSDKException::class,
+                "Values should be non zero",
+            ],
+            [
+                "BTC",
+                true,
+                [
+                    [
+                        "address" => "tb1qn08f8x0eamw66enrt497zu0v3u2danzey6asqs",
+                        "value" => 1,
+                    ]
+                ],
+                BlocktrailSDKException::class,
+                "Values should be more than dust (".Blocktrail::DUST.")",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorFixtures
+     * @param $network
+     * @param $testnet
+     * @param array $input
+     * @param $exception
+     * @param $exceptionMsg
+     * @throws BlocktrailSDKException
+     */
+    public function testErrorCase($network, $testnet, array $input, $exception, $exceptionMsg)
+    {
+        list ($network, $addressReader) = $this->loadAddressReader($network, $testnet);
+
+        $normalizer = new OutputsNormalizer($addressReader);
+
+        $this->setExpectedException($exception, $exceptionMsg);
+
+        $normalizer->normalize($input, $network);
+
+    }
+}

--- a/tests/WalletTest.php
+++ b/tests/WalletTest.php
@@ -21,6 +21,7 @@ use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
 use Blocktrail\CryptoJSAES\CryptoJSAES;
+use Blocktrail\SDK\Address\BitcoinAddressReader;
 use Blocktrail\SDK\Bitcoin\BIP32Key;
 use Blocktrail\SDK\Blocktrail;
 use Blocktrail\SDK\BlocktrailSDK;
@@ -161,6 +162,7 @@ class WalletTest extends BlocktrailTestCase {
         $blocktrailPublicKeys = $result['blocktrail_public_keys'];
         $keyIndex = $result['key_index'];
 
+        // todo: this hardcodes bitcoin, and testnet, despite the SDK client being initialized outside this function
         $wallet = new WalletV2(
             $client,
             $identifier,
@@ -173,6 +175,7 @@ class WalletTest extends BlocktrailTestCase {
             'bitcoin',
             $testnet,
             false,
+            new BitcoinAddressReader(),
             $checksum
         );
 
@@ -367,7 +370,7 @@ class WalletTest extends BlocktrailTestCase {
 
         $rand = random_int(1, 3);
 
-        $builder = (new TransactionBuilder())
+        $builder = (new TransactionBuilder($segwitwallet->getAddressReader()))
             ->addRecipient($address, BlocktrailSDK::toSatoshi(0.015) * $rand)
             ->setFeeStrategy(Wallet::FEE_STRATEGY_BASE_FEE);
 
@@ -405,7 +408,7 @@ class WalletTest extends BlocktrailTestCase {
 
         $utxo = $tx['outputs'][$utxoIdx];
 
-        $spendSegwit = (new TransactionBuilder())
+        $spendSegwit = (new TransactionBuilder($segwitwallet->getAddressReader()))
             ->addRecipient($segwitwallet->getNewAddress(), BlocktrailSDK::toSatoshi(0.010) * $rand)
             ->spendOutput($tx['hash'], $utxoIdx, $utxo['value'], $utxo['address'], $utxo['script_hex'], $path)
             ->setFeeStrategy(Wallet::FEE_STRATEGY_BASE_FEE);
@@ -467,7 +470,7 @@ class WalletTest extends BlocktrailTestCase {
         $random = random_int(1, 4);
         $receiveAmount = BlocktrailSDK::toSatoshi(0.0001) * $random;
 
-        $builder = (new TransactionBuilder())
+        $builder = (new TransactionBuilder($unittestWallet->getAddressReader()))
             ->addRecipient($addr->getAddress(), $receiveAmount)
             ->setFeeStrategy(Wallet::FEE_STRATEGY_OPTIMAL);
 
@@ -533,7 +536,7 @@ class WalletTest extends BlocktrailTestCase {
         $fundTx = [];
         $fundTxOutIdx = [];
 
-        $builder = (new TransactionBuilder())
+        $builder = (new TransactionBuilder($unittestWallet->getAddressReader()))
             ->addRecipient($unittestAddress, BlocktrailSDK::toSatoshi(0.0003))
             ->setFeeStrategy(Wallet::FEE_STRATEGY_OPTIMAL);
 
@@ -743,7 +746,7 @@ class WalletTest extends BlocktrailTestCase {
          */
         $value = BlocktrailSDK::toSatoshi(0.0002);
         $moon = "MOOOOOOOOOOOOON!";
-        $txBuilder = new TransactionBuilder();
+        $txBuilder = new TransactionBuilder($wallet->getAddressReader());
         $txBuilder->randomizeChangeOutput(false);
         $txBuilder->addRecipient($address, $value);
         $txBuilder->addOpReturn($moon);
@@ -1341,7 +1344,7 @@ class WalletTest extends BlocktrailTestCase {
         /** @var Transaction $tx */
         /** @var SignInfo[] $signInfo */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     $txid,
                     $vout,
@@ -1411,7 +1414,7 @@ class WalletTest extends BlocktrailTestCase {
         /** @var Transaction $tx */
         /** @var SignInfo[] $signInfo */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "0d8703ab259b03a757e37f3cdba7fc4543e8d47f7cc3556e46c0aeef6f5e832b",
                     0,
@@ -1487,7 +1490,7 @@ class WalletTest extends BlocktrailTestCase {
         try {
             /** @var Transaction $tx */
             list($tx, $signInfo) = $wallet->buildTx(
-                (new TransactionBuilder())
+                (new TransactionBuilder($wallet->getAddressReader()))
                     ->spendOutput(
                         "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                         0,
@@ -1514,7 +1517,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1576,7 +1579,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1646,7 +1649,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1716,7 +1719,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1788,7 +1791,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1846,7 +1849,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
@@ -1883,7 +1886,7 @@ class WalletTest extends BlocktrailTestCase {
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
-            (new TransactionBuilder())
+            (new TransactionBuilder($wallet->getAddressReader()))
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,

--- a/tests/WalletTest.php
+++ b/tests/WalletTest.php
@@ -1633,16 +1633,16 @@ class WalletTest extends BlocktrailTestCase {
         /*
          * test change output bumps size over 1kb, fee += 0.0001
          *
-         * 1 input (1 * 294b) = 294b
-         * 20 recipients (19 * 34b) = 680b
+         * 1 input (1 * 298b) = 298b
+         * 20 recipients (19 * 33b) = 693b
          *
-         * size = 8b + 294b + 680b = 982b
-         * + change output (34b) = 1006b
+         * size = 8b + 298b + 693b = 999b
+         * + change output (34b) = 1019b
          *
          * fee = 0.0002
          * input = 1.0000
-         * 1.0000 - (20 * 0.0001) = 0.9980
-         * change = 0.9978
+         * 1.0000 - (20 * 0.0001) = 0.9977
+         * change = 0.9977
          */
         $utxos = [
             'ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396' => BlocktrailSDK::toSatoshi(1)
@@ -1679,6 +1679,7 @@ class WalletTest extends BlocktrailTestCase {
                 ->addRecipient("2NAHY321fSVz4wKnE4eWjyLfRmoauCrQpBD", BlocktrailSDK::toSatoshi(0.0001))
                 ->addRecipient("2N2anz2GmZdrKNNeEZD7Xym8djepwnTqPXY", BlocktrailSDK::toSatoshi(0.0001))
                 ->addRecipient("2Mvs5ik3nC9RBho2kPcgi5Q62xxAE2Aryse", BlocktrailSDK::toSatoshi(0.0001))
+                ->addRecipient("2Mvs5ik3nC9RBho2kPcgi5Q62xxAE2Aryse", BlocktrailSDK::toSatoshi(0.0001))
                 ->setChangeAddress("2N6DJMnoS3xaxpCSDRMULgneCghA1dKJBmT")
                 ->randomizeChangeOutput(false)
                 ->setFeeStrategy(Wallet::FEE_STRATEGY_BASE_FEE)
@@ -1697,9 +1698,10 @@ class WalletTest extends BlocktrailTestCase {
         $this->assertEquals(BlocktrailSDK::toSatoshi(1), $inputTotal);
         $this->assertEquals(BlocktrailSDK::toSatoshi(0.9998), $outputTotal);
         $this->assertEquals(BlocktrailSDK::toSatoshi(0.0002), $fee);
-        $this->assertEquals(21, count($tx->getOutputs()));
-        $this->assertEquals("2N6DJMnoS3xaxpCSDRMULgneCghA1dKJBmT", AddressFactory::fromOutputScript($tx->getOutput(20)->getScript())->getAddress());
-        $this->assertEquals(BlocktrailSDK::toSatoshi(0.9978), $tx->getOutput(20)->getValue());
+        $this->assertEquals(22, count($tx->getOutputs()));
+        $change = $tx->getOutput(21);
+        $this->assertEquals("2N6DJMnoS3xaxpCSDRMULgneCghA1dKJBmT", AddressFactory::fromOutputScript($change->getScript())->getAddress());
+        $this->assertEquals(BlocktrailSDK::toSatoshi(0.9977), $change->getValue());
 
         /*
          * test change
@@ -1773,21 +1775,21 @@ class WalletTest extends BlocktrailTestCase {
          * test change output bumps size over 1kb, fee += 0.0001
          *  but change was < 0.0001 so better to just fee it all
          *
-         * 1 input (1 * 294b) = 294b
-         * 20 recipients (19 * 34b) = 680b
+         * 1 input (1 * 294b) = 298b
+         * 20 recipients (20 * 34b) = 660b
          *
-         * input = 0.00219
+         * input = 0.00212
          *
-         * size = 8b + 294b + 680b = 982b
+         * size = 8b + 298b + 660b = 986b
          * fee = 0.0001
-         * 0.00219 - (20 * 0.0001) = 0.00019
+         * 0.00212 - (20 * 0.0001) = 0.00012
          *
          * + change output (0.00009) (34b) = 1006b
          * fee = 0.0002
-         * 0.00219 - (20 * 0.0001) = 0.00019
+         *
          */
         $utxos = [
-            'ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396' => BlocktrailSDK::toSatoshi(0.00219)
+            'ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396' => BlocktrailSDK::toSatoshi(0.00212)
         ];
         /** @var Transaction $tx */
         list($tx, $signInfo) = $wallet->buildTx(
@@ -1795,7 +1797,7 @@ class WalletTest extends BlocktrailTestCase {
                 ->spendOutput(
                     "ed6458f2567c3a6847e96ca5244c8eb097efaf19fd8da2d25ec33d54a49b4396",
                     0,
-                    BlocktrailSDK::toSatoshi(0.00219),
+                    BlocktrailSDK::toSatoshi(0.00212),
                     "2N6DJMnoS3xaxpCSDRMULgneCghA1dKJBmT",
                     "a9148e3c73aaf758dc4f4186cd49c3d523954992a46a87",
                     "M/9999'/0/1537",
@@ -1836,9 +1838,9 @@ class WalletTest extends BlocktrailTestCase {
         $fee = $inputTotal - $outputTotal;
 
         // assert the output(s)
-        $this->assertEquals(BlocktrailSDK::toSatoshi(0.00219), $inputTotal);
+        $this->assertEquals(BlocktrailSDK::toSatoshi(0.00212), $inputTotal);
         $this->assertEquals(BlocktrailSDK::toSatoshi(0.0020), $outputTotal);
-        $this->assertEquals(BlocktrailSDK::toSatoshi(0.00019), $fee);
+        $this->assertEquals(BlocktrailSDK::toSatoshi(0.00012), $fee);
         $this->assertEquals(20, count($tx->getOutputs()));
 
         /*


### PR DESCRIPTION
Adds bitcoin cash address support to public methods, toggled by the `use_cashaddress` $option in initWallet and createNewWallet.
Reminder: for bitcoin cash you set 'BCC' as the network, 'tBCC' for testnet. 