### PR TITLE
Solver error qr-code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "rych/hash_pbkdf2-compat": "~1.0",
         "ramsey/array_column": "~1.1",
         "dompdf/dompdf" : "0.6.*",
-        "endroid/qrcode": "1.5.*",
+        "endroid/qr-code": "1.5.*",
         "blocktrail/cryptojs-aes-php": "0.1.*",
         "spomky-labs/php-aes-gcm": "v1.2.0"
     },


### PR DESCRIPTION
Package endroid/qrcode is abandoned, you should avoid using it. Use endroid/qr-code instead.